### PR TITLE
Update to manual numbering instead of using css ordered lists.

### DIFF
--- a/css/2024-2025.css
+++ b/css/2024-2025.css
@@ -3,7 +3,7 @@
     line-height: 1.5em;
 }
 
-ul.main-rules {
+#rules-of-ultimate ul.main-rules {
     list-style-type: none;
     list-style-position: outside;
     margin: 1.5rem 0;
@@ -11,19 +11,23 @@ ul.main-rules {
     padding: 0;
 }
 
-ul.main-rules li {
+#rules-of-ultimate ul.main-rules li {
+    list-style-type: none;
+}
+
+#rules-of-ultimate ul.main-rules li {
     color: #B30839;
     font-size: 1.5rem;
     margin: 1rem 0;
 }
 
-ul.main-rules ul > li {
+#rules-of-ultimate ul.main-rules ul > li {
     color: #000;
     font-size: 1rem;
     margin: 0;
 }
 
-ul.main-rules ul {
+#rules-of-ultimate ul.main-rules ul {
     list-style-type: none;
     list-style-position: outside;
     margin: .25rem 0;
@@ -31,30 +35,38 @@ ul.main-rules ul {
     padding-inline-start: 1rem;
 }
 
-ul.main-rules ul li:first-child {
+#rules-of-ultimate ul.main-rules ul li:first-child {
     margin-top: .75rem;
 }
 
-ul.main-rules ul ul li:first-child {
+#rules-of-ultimate ul.main-rules ul ul li:first-child {
     margin-top: 0;
 }
 
-ul.main-rules li > a:first-child {
+#rules-of-ultimate ul.main-rules li > a:first-child {
     font-weight: bold;
+    color: black;
+    transition: none;
+    text-decoration: none;
+    text-transform: none;
 }
 
-ul.main-rules div.plain {
+#rules-of-ultimate ul.main-rules > li > a:first-child {
+    color: #B30839;
+}
+
+#rules-of-ultimate ul.main-rules div.plain {
     color: #000;
     font-size: 1rem;
     font-weight: normal;
     margin: 1rem 0 0 1rem;
 }
 
-ul.main-rules table {
+#rules-of-ultimate ul.main-rules table {
     margin: 1rem 0;
 }
 
-ul.main-rules ul.examples {
+#rules-of-ultimate ul.main-rules ul.examples li {
     list-style-type: disc;
     list-style-position: outside;
     margin-left: .5rem;
@@ -226,5 +238,21 @@ ul.main-rules ul.examples {
     font-size: 1em;
     color: #B30839;
     font-size: 1.5rem;
+}
+
+#rules-of-ultimate .rules tbody td {
+    width: 50%;
+    padding: 1rem;
+    vertical-align: top;
+    font-size: 0.875rem;
+    border-top: 1px solid #e5e5e5;
+}
+
+#rules-of-ultimate .rules tbody tr td:first-of-type {
+    font-weight: bold;
+}
+
+#rules-of-ultimate .rules tbody tr:nth-child(even) {
+    background: #fafafa;
 }
 /* END RULES */

--- a/css/2024-2025.css
+++ b/css/2024-2025.css
@@ -1,0 +1,342 @@
+/* START RULES */
+#rules-of-ultimate {
+    line-height: 1.5em;
+}
+
+ol.appendices,
+ol.main-rules {
+    counter-reset: level-one;
+    list-style-type: none;
+    list-style-position: outside;
+    margin: 1.5rem 0;
+    font-weight: bold;
+}
+
+ol.appendices li,
+ol.main-rules li {
+    color: #B30839;
+    font-size: 1.5rem;
+}
+
+ol.appendices ol li,
+ol.main-rules ol li {
+    color: #000;
+    font-size: 1rem;
+    margin: 0;
+}
+
+ol.main-rules li::before {
+    counter-increment: level-one;
+    content: counter(level-one) ". ";
+}
+
+ol.appendices li::before {
+    counter-increment: level-one;
+    content: "Appendix "counter(level-one, upper-alpha) ": ";
+}
+
+ol.appendices ol,
+ol.main-rules ol {
+    list-style-type: none;
+    list-style-position: outside;
+    counter-reset: level-two;
+    margin: 1rem 0 1rem 1rem;
+    font-weight: normal;
+}
+
+ol.main-rules ol li::before {
+    font-weight: bold;
+    counter-increment: level-two;
+    content: counter(level-one) "."counter(level-two, upper-alpha) ". ";
+}
+
+ol.appendices ol li::before {
+    font-weight: bold;
+    counter-increment: level-two;
+    content: counter(level-one, upper-alpha) ""counter(level-two) ". ";
+}
+
+ol.appendices ol li {
+    font-weight: bold;
+}
+
+ol.appendices ol ol,
+ol.main-rules ol ol {
+    list-style-type: none;
+    list-style-position: outside;
+    margin: 0 0 0 1rem;
+    counter-reset: level-three;
+}
+
+ol.main-rules ol ol li::before {
+    counter-increment: level-three;
+    content: counter(level-one) "."counter(level-two, upper-alpha) "."counter(level-three) ". ";
+}
+
+ol.appendices ol ol li::before {
+    counter-increment: level-three;
+    content: counter(level-one, upper-alpha) ""counter(level-two) "."counter(level-three, upper-alpha) ". ";
+}
+
+ol.appendices ol ol {
+    padding-top: .5rem;
+}
+
+ol.appendices ol ol li {
+    font-weight: normal;
+}
+
+
+ol.appendices ol ol ol,
+ol.main-rules ol ol ol {
+    list-style-type: none;
+    counter-reset: level-four;
+}
+
+ol.main-rules ol ol ol li::before {
+    counter-increment: level-four;
+    content: counter(level-one) "."counter(level-two, upper-alpha) "."counter(level-three) "."counter(level-four, lower-alpha) ". ";
+}
+
+ol.appendices ol ol ol li::before {
+    counter-increment: level-four;
+    content: counter(level-one, upper-alpha) ""counter(level-two) "."counter(level-three, upper-alpha) "."counter(level-four) ". ";
+}
+
+ol.appendices ol ol ol {
+    padding-top: 0;
+}
+
+ol.appendices ol ol ol ol,
+ol.main-rules ol ol ol ol {
+    list-style-type: none;
+    counter-reset: level-five;
+}
+
+ol.main-rules ol ol ol ol li::before {
+    counter-increment: level-five;
+    content: counter(level-one) "."counter(level-two, upper-alpha) "."counter(level-three) "."counter(level-four, lower-alpha) "."counter(level-five) ". ";
+}
+
+ol.appendices ol ol ol ol li::before {
+    counter-increment: level-five;
+    content: counter(level-one, upper-alpha) ""counter(level-two) "."counter(level-three, upper-alpha) "."counter(level-four) "."counter(level-five, lower-alpha) ". ";
+}
+
+ol.appendices ol ol ol ol ol,
+ol.main-rules ol ol ol ol ol {
+    list-style-type: none;
+    counter-reset: level-six;
+}
+
+ol.main-rules ol ol ol ol ol li::before {
+    counter-increment: level-six;
+    content: counter(level-one) "."counter(level-two, upper-alpha) "."counter(level-three) "."counter(level-four, lower-alpha) "."counter(level-five) "."counter(level-six, lower-alpha) ". "
+}
+
+ol.appendices ol ol ol ol ol li::before {
+    counter-increment: level-six;
+    content: counter(level-one, upper-alpha) ""counter(level-two) "."counter(level-three, upper-alpha) "."counter(level-four) "."counter(level-five, lower-alpha) "."counter(level-six) ". "
+}
+
+ol.main-rules ol ul li::before {
+    content: none;
+}
+
+}
+
+ol.main-rules li {
+    color: #B30839;
+    font-size: 1.5rem;
+}
+
+ol.appendices div.plain {
+    color: #000;
+    font-size: 1rem;
+    font-weight: normal;
+    margin: 1rem 0 0 1rem;
+}
+
+ol.appendices table {
+    margin: 1rem 0;
+}
+
+
+ol.appendices li:first-child,
+ol.main-rules li:first-child {
+    margin-top: .5rem;
+}
+
+ol.appendices li:last-child,
+ol.main-rules li:last-child {
+    margin-bottom: .5rem;
+}
+
+#rules-of-ultimate .tooltip {
+    position: relative;
+    display: inline;
+    padding-bottom: 0;
+    border-bottom: 1px dashed #B30839;
+}
+
+#rules-of-ultimate .tooltip:hover {
+    cursor: pointer;
+}
+
+#rules-of-ultimate .handSignals img {
+    max-height: 300px;
+}
+
+#rules-of-ultimate .handSignals {
+    text-align: center;
+}
+
+#rules-of-ultimate .handSignals td {
+    padding-top: 0;
+    width: 300px;
+}
+
+#rules-of-ultimate table.handSignals,
+#rules-of-ultimate table.fieldDiagram,
+#rules-of-ultimate table.normal {
+    border-collapse: collapse;
+    font-size: 1em;
+    font-weight: normal;
+}
+
+#rules-of-ultimate table.fieldDiagram {
+    margin-left: 1rem;
+}
+
+#rules-of-ultimate .handSignals {
+    margin-top: 2rem;
+}
+
+#rules-of-ultimate .handSignals td {
+    vertical-align: middle;
+}
+
+#rules-of-ultimate .handSignals td img {
+    margin: 0 auto;
+}
+
+#rules-of-ultimate .handSignals .desc td {
+    font-weight: bold;
+    font-family: proxima-nova, sans-serif;
+    font-size: 0.875rem;
+    color: #002B5C;
+    padding: 0 0 2rem 0;
+}
+
+#rules-of-ultimate #field_lines {
+    width: 30px;
+}
+
+#rules-of-ultimate #field_line_names {
+    padding-top: 9px;
+}
+
+#rules-of-ultimate .fieldSizeHeader {
+    text-decoration: underline;
+}
+
+#rules-of-ultimate .annotation {
+    font-size: 0.875rem;
+    font-style: italic;
+}
+
+#rules-of-ultimate .youth tbody {
+    font-size: 0.875rem;
+    margin-top: 2rem;
+}
+
+#rules-of-ultimate .youth tbody td {
+    color: #000;
+}
+
+#rules-of-ultimate .youth tbody tr:first-of-type {
+    font-weight: bold;
+    background: #002B5C;
+    color: #fff;
+}
+
+#rules-of-ultimate .youth tbody tr:first-of-type td {
+    color: #fff;
+}
+
+#rules-of-ultimate .youth tbody tr:first-of-type td {
+    padding: 0.5rem 1rem;
+}
+
+#rules-of-ultimate .youth tbody tr:nth-child(even) {
+    background: #eee;
+}
+
+#rules-of-ultimate .youth tbody tr td:first-of-type {
+    font-weight: bold;
+}
+
+#rules-of-ultimate .youth tbody td {
+    padding: 1rem;
+    vertical-align: top;
+}
+
+#rules-of-ultimate .youth tbody li {
+    font-size: 0.825rem;
+    color: #000;
+}
+
+#rules-of-ultimate .youth tbody li::before {
+    content: none;
+}
+
+#rules-of-ultimate .table-of-contents {
+    border: 1px solid #002B5C;
+    padding: 2rem;
+    max-width: 340px;
+    font-size: 0.9375rem;
+}
+
+#rules-of-ultimate .table-of-contents ol {
+    margin-left: 1.5rem;
+}
+
+#rules-of-ultimate .table-of-contents ol li {
+    font-weight: normal;
+}
+
+#rules-of-ultimate .table-of-contents .toc-header {
+    padding-bottom: 0.5rem;
+}
+
+#rules-of-ultimate .table-of-contents .toc-preface {
+    padding: 0 0 0.5rem 0;
+}
+
+#rules-of-ultimate .table-of-contents .toc-rules li {
+    padding-left: 0.25rem;
+    color: #002B5C;
+}
+
+#rules-of-ultimate .table-of-contents .toc-appendix {
+    padding: 0.5rem 0 0 0;
+}
+
+#rules-of-ultimate .table-of-contents .toc-appendix p + p {
+    padding-top: 0.5rem;
+}
+
+#rules-of-ultimate p#prefaceBody {
+    font-style: italic;
+    font-size: 1em;
+    margin: .5rem 0 1em 0;
+}
+
+#rules-of-ultimate p#preface_title {
+    margin-top: 3em;
+    font-weight: bold;
+    font-size: 1em;
+    color: #B30839;
+    font-size: 1.5rem;
+}
+/* END RULES */

--- a/css/2024-2025.css
+++ b/css/2024-2025.css
@@ -3,173 +3,61 @@
     line-height: 1.5em;
 }
 
-ol.appendices,
-ol.main-rules {
-    counter-reset: level-one;
+ul.main-rules {
     list-style-type: none;
     list-style-position: outside;
     margin: 1.5rem 0;
     font-weight: bold;
+    padding: 0;
 }
 
-ol.appendices li,
-ol.main-rules li {
+ul.main-rules li {
     color: #B30839;
     font-size: 1.5rem;
+    margin: 1rem 0;
 }
 
-ol.appendices ol li,
-ol.main-rules ol li {
+ul.main-rules ul > li {
     color: #000;
     font-size: 1rem;
     margin: 0;
 }
 
-ol.main-rules li::before {
-    counter-increment: level-one;
-    content: counter(level-one) ". ";
-}
-
-ol.appendices li::before {
-    counter-increment: level-one;
-    content: "Appendix "counter(level-one, upper-alpha) ": ";
-}
-
-ol.appendices ol,
-ol.main-rules ol {
+ul.main-rules ul {
     list-style-type: none;
     list-style-position: outside;
-    counter-reset: level-two;
-    margin: 1rem 0 1rem 1rem;
+    margin: .25rem 0;
     font-weight: normal;
+    padding-inline-start: 1rem;
 }
 
-ol.main-rules ol li::before {
-    font-weight: bold;
-    counter-increment: level-two;
-    content: counter(level-one) "."counter(level-two, upper-alpha) ". ";
+ul.main-rules ul li:first-child {
+    margin-top: .75rem;
 }
 
-ol.appendices ol li::before {
-    font-weight: bold;
-    counter-increment: level-two;
-    content: counter(level-one, upper-alpha) ""counter(level-two) ". ";
+ul.main-rules ul ul li:first-child {
+    margin-top: 0;
 }
 
-ol.appendices ol li {
+ul.main-rules li > a:first-child {
     font-weight: bold;
 }
 
-ol.appendices ol ol,
-ol.main-rules ol ol {
-    list-style-type: none;
-    list-style-position: outside;
-    margin: 0 0 0 1rem;
-    counter-reset: level-three;
-}
-
-ol.main-rules ol ol li::before {
-    counter-increment: level-three;
-    content: counter(level-one) "."counter(level-two, upper-alpha) "."counter(level-three) ". ";
-}
-
-ol.appendices ol ol li::before {
-    counter-increment: level-three;
-    content: counter(level-one, upper-alpha) ""counter(level-two) "."counter(level-three, upper-alpha) ". ";
-}
-
-ol.appendices ol ol {
-    padding-top: .5rem;
-}
-
-ol.appendices ol ol li {
-    font-weight: normal;
-}
-
-
-ol.appendices ol ol ol,
-ol.main-rules ol ol ol {
-    list-style-type: none;
-    counter-reset: level-four;
-}
-
-ol.main-rules ol ol ol li::before {
-    counter-increment: level-four;
-    content: counter(level-one) "."counter(level-two, upper-alpha) "."counter(level-three) "."counter(level-four, lower-alpha) ". ";
-}
-
-ol.appendices ol ol ol li::before {
-    counter-increment: level-four;
-    content: counter(level-one, upper-alpha) ""counter(level-two) "."counter(level-three, upper-alpha) "."counter(level-four) ". ";
-}
-
-ol.appendices ol ol ol {
-    padding-top: 0;
-}
-
-ol.appendices ol ol ol ol,
-ol.main-rules ol ol ol ol {
-    list-style-type: none;
-    counter-reset: level-five;
-}
-
-ol.main-rules ol ol ol ol li::before {
-    counter-increment: level-five;
-    content: counter(level-one) "."counter(level-two, upper-alpha) "."counter(level-three) "."counter(level-four, lower-alpha) "."counter(level-five) ". ";
-}
-
-ol.appendices ol ol ol ol li::before {
-    counter-increment: level-five;
-    content: counter(level-one, upper-alpha) ""counter(level-two) "."counter(level-three, upper-alpha) "."counter(level-four) "."counter(level-five, lower-alpha) ". ";
-}
-
-ol.appendices ol ol ol ol ol,
-ol.main-rules ol ol ol ol ol {
-    list-style-type: none;
-    counter-reset: level-six;
-}
-
-ol.main-rules ol ol ol ol ol li::before {
-    counter-increment: level-six;
-    content: counter(level-one) "."counter(level-two, upper-alpha) "."counter(level-three) "."counter(level-four, lower-alpha) "."counter(level-five) "."counter(level-six, lower-alpha) ". "
-}
-
-ol.appendices ol ol ol ol ol li::before {
-    counter-increment: level-six;
-    content: counter(level-one, upper-alpha) ""counter(level-two) "."counter(level-three, upper-alpha) "."counter(level-four) "."counter(level-five, lower-alpha) "."counter(level-six) ". "
-}
-
-ol.main-rules ol ul li::before {
-    content: none;
-}
-
-}
-
-ol.main-rules li {
-    color: #B30839;
-    font-size: 1.5rem;
-}
-
-ol.appendices div.plain {
+ul.main-rules div.plain {
     color: #000;
     font-size: 1rem;
     font-weight: normal;
     margin: 1rem 0 0 1rem;
 }
 
-ol.appendices table {
+ul.main-rules table {
     margin: 1rem 0;
 }
 
-
-ol.appendices li:first-child,
-ol.main-rules li:first-child {
-    margin-top: .5rem;
-}
-
-ol.appendices li:last-child,
-ol.main-rules li:last-child {
-    margin-bottom: .5rem;
+ul.main-rules ul.examples {
+    list-style-type: disc;
+    list-style-position: outside;
+    margin-left: .5rem;
 }
 
 #rules-of-ultimate .tooltip {
@@ -329,11 +217,11 @@ ol.main-rules li:last-child {
 #rules-of-ultimate p#prefaceBody {
     font-style: italic;
     font-size: 1em;
-    margin: .5rem 0 1em 0;
+    margin: 0 0 1em 0;
 }
 
 #rules-of-ultimate p#preface_title {
-    margin-top: 3em;
+    margin: 3em 0 .75rem 0;
     font-weight: bold;
     font-size: 1em;
     color: #B30839;

--- a/html/2024-2025.html
+++ b/html/2024-2025.html
@@ -476,7 +476,7 @@
                             <span class="tooltip" title="A scoring attempt starts at the beginning of the game or when the previous goal is scored and ends when the next goal is scored.">scoring attempt</span>
                             is completed. If, after the current scoring attempt is completed, the game total has not yet been reached by one team, one is added to the higher score and the resulting number is the new game total.
                             <ul>
-                                <li><a id="#6.C.1.a">#6.C.1.a.</a> If the soft cap occurs during the halftime break, the new game total is one more than the higher score. <span class="annotation">[[Don't play a point and then add one.]]</span></li>
+                                <li><a id="6.C.1.a">6.C.1.a.</a> If the soft cap occurs during the halftime break, the new game total is one more than the higher score. <span class="annotation">[[Don't play a point and then add one.]]</span></li>
                             </ul>
                         </li>
                         <li>
@@ -484,7 +484,7 @@
                             <span class="tooltip" title="A scoring attempt starts at the beginning of the game or when the previous goal is scored and ends when the next goal is scored.">scoring attempt</span>
                             is completed. If, after the current scoring attempt is completed, the score is tied, play continues until one additional goal is scored. Otherwise, the game ends. The team with the most goals at the end of the game is the winner.
                             <ul>
-                                <li><a id="#6.C.2.a">#6.C.2.a.</a> If the hard cap occurs during the halftime break, the game is over and the team with the higher score is the winner.</li>
+                                <li><a id="6.C.2.a">6.C.2.a.</a> If the hard cap occurs during the halftime break, the game is over and the team with the higher score is the winner.</li>
                             </ul>
                         </li>
                         <li>
@@ -551,7 +551,7 @@
                         <li>
                             <a id="7.C.2">7.C.2.</a> The timeout is retroactive to the time of the injury, unless the injured player chooses to continue play before the timeout is called, in which case, the timeout begins at the time of the call. If the disc is in the air or the thrower is in the act of throwing at the time of the injury or of the call when the player has continued play, the timeout begins when the play is completed.
                             <ul>
-                                <li><a id="#7.C.2.a">#7.C.2.a.</a> The health and safety of the injured player are of primary concern. If a serious injury occurs, other players change their behavior as a result of that injury, and the captains of both teams agree, the play may be resolved or play may be restarted in any appropriate manner despite any outcome dictated by these rules. <span class="annotation">[[This could include, for example, returning a thrown disc to the thrower regardless of the outcome, restarting the point with a re-pull, or delaying the restart of play.]]</span></li>
+                                <li><a id="7.C.2.a">7.C.2.a.</a> The health and safety of the injured player are of primary concern. If a serious injury occurs, other players change their behavior as a result of that injury, and the captains of both teams agree, the play may be resolved or play may be restarted in any appropriate manner despite any outcome dictated by these rules. <span class="annotation">[[This could include, for example, returning a thrown disc to the thrower regardless of the outcome, restarting the point with a re-pull, or delaying the restart of play.]]</span></li>
                             </ul>
                         </li>
                         <li>
@@ -1030,7 +1030,7 @@
                             <span class="annotation">[[In this case, the player and the disc are considered in-bounds.]]</span>
                         </li>
                         <li><a id="10.C.3">10.C.3.</a> Contact between players does not confer the state of being in- or out-of-bounds from one to another.</li>
-                        <li><a id="#10.C.4">#10.C.4.</a> If a player catches an in-bounds disc and would reasonably have been able to land in-bounds, but lands on an opposing player in a way that causes their first ground contact to be out-of-bounds, this is to be treated as a force-out foul and <a href="https://usaultimate.org/rules/#17.I.4.b.4">17.I.4.b.4</a> applies. For this exception to apply, the play resulting in the landing contact cannot be construed as a <a href="https://usaultimate.org/rules/#17.I.1">dangerous play</a>. <span class="annotation">[[In this case, calls will be resolved in chronological order with the dangerous play superseding the force-out foul.]]</span></li>
+                        <li><a id="10.C.4">10.C.4.</a> If a player catches an in-bounds disc and would reasonably have been able to land in-bounds, but lands on an opposing player in a way that causes their first ground contact to be out-of-bounds, this is to be treated as a force-out foul and <a href="https://usaultimate.org/rules/#17.I.4.b.4">17.I.4.b.4</a> applies. For this exception to apply, the play resulting in the landing contact cannot be construed as a <a href="https://usaultimate.org/rules/#17.I.1">dangerous play</a>. <span class="annotation">[[In this case, calls will be resolved in chronological order with the dangerous play superseding the force-out foul.]]</span></li>
                     </ul>
                 </li>
 
@@ -1312,13 +1312,13 @@
                                     <a id="15.A.2.b">15.A.2.b.</a> However, unless <a href="https://usaultimate.org/rules/#15.A.2.a">15.A.2.a</a> applies, the stall count may not be initiated or resumed before a pivot is established:
                                     <ul>
                                         <li>
-                                            <a id="15.A.2.b.1">15.A.2.b.1.dire ctly after a turnover,</a>
+                                            <a id="15.A.2.b.1">15.A.2.b.1.</a> directly after a turnover,</a>
                                         </li>
                                         <li>
-                                            <a id="15.A.2.b.2">15.A.2.b.2.when  putting the pull into play, and</a>
+                                            <a id="15.A.2.b.2">15.A.2.b.2.</a> when putting the pull into play, and</a>
                                         </li>
                                         <li>
-                                            <a id="15.A.2.b.3">15.A.2.b.3.afte r a travel is called and no pass has been attempted.</a>
+                                            <a id="15.A.2.b.3">15.A.2.b.3.</a> after a travel is called and no pass has been attempted.</a>
                                         </li>
                                     </ul>
                                 </li>
@@ -2880,7 +2880,7 @@
                 <li>
                     <a id="E1">E1.</a> Number of Players
                     <ul>
-                        <li>The recommended number of players per team is either five (5) or four (4).</li>
+                        <li><a id="E1.A">E1.A.</a> The recommended number of players per team is either five (5) or four (4).</li>
                     </ul>
                 </li>
 
@@ -2890,25 +2890,25 @@
                         <li>
                             <a id="E2.A">E2.A.</a> 5v5 Field Dimensions
                             <ul>
-                                <li>The standard field of play, including end zones, is 82 yards (75 meters) long and 27 yards (25 meters) wide.</li>
-                                <li>The standard end zone is 16 yards (15 meters) deep.</li>
-                                <li>The brick marks are located 11 yards (10 meters) from the goal line.</li>
+                                <li><a id="E2.A.1">E2.A.1.</a> The standard field of play, including end zones, is 82 yards (75 meters) long and 27 yards (25 meters) wide.</li>
+                                <li><a id="E2.A.2">E2.A.2.</a> The standard end zone is 16 yards (15 meters) deep.</li>
+                                <li><a id="E2.A.3">E2.A.3.</a> The brick marks are located 11 yards (10 meters) from the goal line.</li>
                             </ul>
                         </li>
 
                         <li>
                             <a id="E2.B">E2.B.</a> 4v4 Field Dimensions
                             <ul>
-                                <li>The standard field of play, including end zones, is 50 yards (45 meters) long and 30 yards (27 meters) wide.</li>
-                                <li>The standard end zone is 8 yards (7.5 meters) deep.</li>
-                                <li>The brick marks are located 8 yards (7.5 meters) from the goal line.</li>
+                                <li><a id="E2.B.1">E2.B.1.</a> The standard field of play, including end zones, is 50 yards (45 meters) long and 30 yards (27 meters) wide.</li>
+                                <li><a id="E2.B.2">E2.B.2.</a> The standard end zone is 8 yards (7.5 meters) deep.</li>
+                                <li><a id="E2.B.3">E2.B.3.</a> The brick marks are located 8 yards (7.5 meters) from the goal line.</li>
                             </ul>
                         </li>
 
                         <li>
                             <a id="E2.C">E2.C.</a> Perimeter and end zone lines are established with field lining tape (preferred) or rope.
                             <ul>
-                                <li>The top of the tape is the portion of the field tape that is facing upwards. Should the tape twist along its length, the “top” is always the side that is facing up, even if that changes along the length.</li>
+                                <li><a id="E2.C.1">E2.C.1.</a> The top of the tape is the portion of the field tape that is facing upwards. Should the tape twist along its length, the “top” is always the side that is facing up, even if that changes along the length.</li>
                             </ul>
                         </li>
 

--- a/html/2024-2025.html
+++ b/html/2024-2025.html
@@ -1343,7 +1343,7 @@
                                     <ul>
                                         <li>
                                             <a id="15.A.3.b.1">15.A.3.b.1.</a> If the pass was complete or
-                                            <a href="https://usaultimate.org/rules/#15.B.5.b">15.B.5.b</a>
+                                            <a href="https://usaultimate.org/rules/#15.B.6.b">15.B.6.b</a>
                                             applies, play stops, players return to their positions at the time of the throw, and possession reverts to the thrower. After a check, the
                                             <span class="tooltip" title="The defensive player within ten feet of the thrower&#39;s pivot or of the thrower if no pivot has been established. If the disc is not in a player&#39;s possession, a defensive player within ten feet of a spot on the field where the disc is to be put into play is considered the marker.">marker</span>
                                             resumes the stall count according to

--- a/html/2024-2025.html
+++ b/html/2024-2025.html
@@ -1,8 +1,3 @@
-<html>
-    <head>
-<link rel="stylesheet" href="../css/2024-2025.css" />
-    </head>
-    <body>
 <div id="rules-of-ultimate">
     <div class="table-of-contents">
         <div class="headline section-header toc-header underline blue">
@@ -3078,4 +3073,3 @@
         </li>
     </ul>
 </div>
-</body></html>

--- a/html/2024-2025.html
+++ b/html/2024-2025.html
@@ -1,3 +1,8 @@
+<html>
+    <head>
+<link rel="stylesheet" href="../css/2024-2025.css" />
+    </head>
+    <body>
 <div id="rules-of-ultimate">
     <div class="table-of-contents">
         <div class="headline section-header toc-header underline blue">
@@ -47,136 +52,136 @@
 
     <p id="preface_title"><a id="preface"></a>Preface</p>
     <p id="prefaceBody">Ultimate is a sport that inspires players and fans alike because of its ability to develop and showcase the athleticism, skill, teamwork, and character of its participants. The arc of the disc in flight, the opportunity for each individual to contribute equally to their team's success, and the trust given to each player to know and uphold the rules make ultimate a sport that is embraced for its fun and excitement on the field and for the community beyond it. As a low-cost sport requiring minimal equipment, offering single and mixed-gender play, and providing a format that builds communication and conflict resolution skills, ultimate provides a welcoming, high value experience for players and fans from a diverse set of backgrounds and experiences. The Official Rules of Ultimate 2024-2025 describes how the game is played, including how players self-officiate and apply the principles of Spirit of the Game in competition.</p>
-    <ol class="main-rules">
+    <ul class="main-rules">
         <li>
-            <a id="1"></a>Introduction
-            <ol>
-                <li><a id="1.A"></a>Description: Ultimate is a non-contact, self-officiated disc sport played by two teams of seven players. The object of the game is to score goals. A goal is scored when a player catches any legal pass in the end zone that player is attacking. A player may not run while holding the disc. The disc is advanced by passing it to other players. The disc may be passed in any direction. Any time a pass is incomplete, a turnover occurs, resulting in an immediate change of the team in possession of the disc. Players are empowered to self-officiate using a framework governed by the principles of Spirit of the Game.</li>
+            <a id="1">1.</a> Introduction
+            <ul>
+                <li><a id="1.A">1.A.</a> Description: Ultimate is a non-contact, self-officiated disc sport played by two teams of seven players. The object of the game is to score goals. A goal is scored when a player catches any legal pass in the end zone that player is attacking. A player may not run while holding the disc. The disc is advanced by passing it to other players. The disc may be passed in any direction. Any time a pass is incomplete, a turnover occurs, resulting in an immediate change of the team in possession of the disc. Players are empowered to self-officiate using a framework governed by the principles of Spirit of the Game.</li>
                 <li>
-                    <a id="1.B"></a>Rules Variations
-                    <ol>
-                        <li><a id="1.B.1"></a>Appendices included in these rules outline rules changes and additions specific to several variations of the sport.</li>
+                    <a id="1.B">1.B.</a> Rules Variations
+                    <ul>
+                        <li><a id="1.B.1">1.B.1.</a> Appendices included in these rules outline rules changes and additions specific to several variations of the sport.</li>
                         <li>
-                            <a id="1.B.2"></a>Event Organizer Clause: The
+                            <a id="1.B.2">1.B.2.</a> Event Organizer Clause: The
                             <span class="tooltip" title="The person(s) or entity organizing and responsible for a competition, whether it is a tournament, tournament series, league, single game, or other type of event. Responsibilities may include, but are not limited to competition rules, safety, event registration and event logistics.">event organizer</span>
                             may modify rules relating to game logistics in order to suit the event. Examples include game length (game total), time limits (time caps), halftime length, number of timeouts, starting time point assessments, uniform requirements, and
                             <span class="tooltip" title="Observers are non-player game officials whose job is to support the players in implementing a safe, fair, and efficient game. Observers carefully watch the action of the game, assist with communication, help uphold self-officiating and the Spirit of the Game, assist with resolving calls as needed, and perform other duties as described in Section 19">observer</span>
                             operations. Any such change must be established before competition starts.
                         </li>
                         <li>
-                            <a id="1.B.3"></a>Captain's Clause: For games not subject to the event organizer clause,<i> </i>a game may be played under any variation of the rules agreed upon by the
+                            <a id="1.B.3">1.B.3.</a> Captain's Clause: For games not subject to the event organizer clause,<i> </i>a game may be played under any variation of the rules agreed upon by the
                             <span class="tooltip" title="A team member, who is eligible to participate in the game, and has been designated to represent the team in decision-making on behalf of the team before, during, and after a game.">captains</span>
                             of the teams involved. Otherwise, any rules variations are subject to approval by the event organizer.
                         </li>
-                    </ol>
+                    </ul>
                 </li>
 
-                <li><a id="1.C"></a>General vs. Specific Rules: Many of these rules are general in nature and cover most situations. However, some rules cover specific situations and override the general case.</li>
-            </ol>
+                <li><a id="1.C">1.C.</a> General vs. Specific Rules: Many of these rules are general in nature and cover most situations. However, some rules cover specific situations and override the general case.</li>
+            </ul>
         </li>
 
         <li>
-            <a id="2"></a>Spirit of the Game
-            <ol>
-                <li><a id="2.A"></a>Spirit of the Game is a set of principles which places the responsibility for fair play on the player. Highly competitive play is encouraged, but never at the expense of mutual respect among competitors, adherence to the agreed upon rules, or the basic joy of play.</li>
-                <li><a id="2.B"></a>All players are responsible for knowing, administering, and adhering to the rules. The integrity of ultimate depends on each player's responsibility to uphold the Spirit of the Game, and this responsibility should remain paramount.</li>
+            <a id="2">2.</a> Spirit of the Game
+            <ul>
+                <li><a id="2.A">2.A.</a> Spirit of the Game is a set of principles which places the responsibility for fair play on the player. Highly competitive play is encouraged, but never at the expense of mutual respect among competitors, adherence to the agreed upon rules, or the basic joy of play.</li>
+                <li><a id="2.B">2.B.</a> All players are responsible for knowing, administering, and adhering to the rules. The integrity of ultimate depends on each player's responsibility to uphold the Spirit of the Game, and this responsibility should remain paramount.</li>
                 <li>
-                    <a id="2.C"></a>It is assumed that no player will intentionally violate the rules; thus there are no harsh penalties for inadvertent infractions, but rather a method for resuming play in a manner that simulates what most likely would have occurred absent the infraction. An intentional infraction is cheating and considered a gross offense against the Spirit of the Game. Players are morally bound to abide by the rules and not gain advantage by knowingly committing an infraction, or calling one where none exists.
-                    <ol>
-                        <li><a id="2.C.1"></a>If a player intentionally or flagrantly violates the rules, the captains of each team should discuss the incident and determine an appropriate outcome, and are not bound by any outcome dictated by these rules.</li>
+                    <a id="2.C">2.C.</a> It is assumed that no player will intentionally violate the rules; thus there are no harsh penalties for inadvertent infractions, but rather a method for resuming play in a manner that simulates what most likely would have occurred absent the infraction. An intentional infraction is cheating and considered a gross offense against the Spirit of the Game. Players are morally bound to abide by the rules and not gain advantage by knowingly committing an infraction, or calling one where none exists.
+                    <ul>
+                        <li><a id="2.C.1">2.C.1.</a> If a player intentionally or flagrantly violates the rules, the captains of each team should discuss the incident and determine an appropriate outcome, and are not bound by any outcome dictated by these rules.</li>
                         <li>
-                            <a id="2.C.1"></a> For behavior warranting sanctions pursuant to <a href="https://usaultimate.org/rules/#appendix_b">Appendix B The Misconduct System</a>, team <span class="tooltip" title="A team member, who is eligible to participate in the game, and has been designated to represent the team in decision-making on behalf of the team before, during, and after a game.">captains</span> or <span class="tooltip" title="A team member who has been officially recognized by event organizers to have met the requirements necessary for coaching, including but not limited to certification, screening, education, and registration. Coaches are permitted in areas where sideline players are allowed, during and between points, in accordance with event rules. Coaches are not permitted to make calls or contribute to the discussion or resolution of calls, except to clarify rules if requested.">coaches</span> may remove players on their team from the game for one point or any
+                            <a id="2.C.1">2.C.1.</a>  For behavior warranting sanctions pursuant to <a href="https://usaultimate.org/rules/#appendix_b">Appendix B The Misconduct System</a>, team <span class="tooltip" title="A team member, who is eligible to participate in the game, and has been designated to represent the team in decision-making on behalf of the team before, during, and after a game.">captains</span> or <span class="tooltip" title="A team member who has been officially recognized by event organizers to have met the requirements necessary for coaching, including but not limited to certification, screening, education, and registration. Coaches are permitted in areas where sideline players are allowed, during and between points, in accordance with event rules. Coaches are not permitted to make calls or contribute to the discussion or resolution of calls, except to clarify rules if requested.">coaches</span> may remove players on their team from the game for one point or any
                             longer duration, to help promote SOTG. Removal shall occur after a point has been scored and before the next pull. However, in cases of ejection-worthy behavior, removal can occur at the next stoppage of play during the current point, with permission of the opposing captain. <span class="tooltip" title="A team member, who is eligible to participate in the game, and has been designated to address, discuss, and resolve spirit issues at any point throughout the competition with their opponents, teammates, coaches, and game or event officials.">Spirit captains</span> should be consulted prior to removal of a player. A captain or coach may permit a removed player to return to play at any time, consistent with rules on substitutions. If a player is substituted by a team in accordance with this rule, the other team may substitute a player.
                         </li>
-                    </ol>
+                    </ul>
                 </li>
 
                 <li>
-                    <a id="2.D"></a>Players should be mindful of the fact that they are acting as officials in any arbitration between teams. Players must:
-                    <ol>
-                        <li><a id="2.D.1"></a>know and abide by the rules;</li>
-                        <li><a id="2.D.2"></a>make calls only where an infraction is significant enough to make a difference to the outcome of the action or where a player's safety is at risk;</li>
-                        <li><a id="2.D.3"></a>be fair-minded and objective;</li>
-                        <li><a id="2.D.4"></a>be truthful;</li>
-                        <li><a id="2.D.5"></a>explain their viewpoint clearly and concisely;</li>
-                        <li><a id="2.D.6"></a>allow opponents a chance to speak;</li>
-                        <li><a id="2.D.7"></a>listen to and consider opponent's viewpoint;</li>
-                        <li><a id="2.D.8"></a>treat your opponents with consideration;</li>
-                        <li><a id="2.D.9"></a>be conscious of the impact of your words and body language;</li>
-                        <li><a id="2.D.10"></a>resolve disputes efficiently;</li>
-                        <li><a id="2.D.11"></a>make calls in a consistent manner throughout the game and from player to player; and</li>
-                        <li><a id="2.D.12"></a>acknowledge potential bias and preconceptions in order to treat every player equitably</li>
-                    </ol>
+                    <a id="2.D">2.D.</a> Players should be mindful of the fact that they are acting as officials in any arbitration between teams. Players must:
+                    <ul>
+                        <li><a id="2.D.1">2.D.1.</a> know and abide by the rules;</li>
+                        <li><a id="2.D.2">2.D.2.</a> make calls only where an infraction is significant enough to make a difference to the outcome of the action or where a player's safety is at risk;</li>
+                        <li><a id="2.D.3">2.D.3.</a> be fair-minded and objective;</li>
+                        <li><a id="2.D.4">2.D.4.</a> be truthful;</li>
+                        <li><a id="2.D.5">2.D.5.</a> explain their viewpoint clearly and concisely;</li>
+                        <li><a id="2.D.6">2.D.6.</a> allow opponents a chance to speak;</li>
+                        <li><a id="2.D.7">2.D.7.</a> listen to and consider opponent's viewpoint;</li>
+                        <li><a id="2.D.8">2.D.8.</a> treat your opponents with consideration;</li>
+                        <li><a id="2.D.9">2.D.9.</a> be conscious of the impact of your words and body language;</li>
+                        <li><a id="2.D.10">2.D.10.</a> resolve disputes efficiently;</li>
+                        <li><a id="2.D.11">2.D.11.</a> make calls in a consistent manner throughout the game and from player to player; and</li>
+                        <li><a id="2.D.12">2.D.12.</a> acknowledge potential bias and preconceptions in order to treat every player equitably</li>
+                    </ul>
                     <div class="annotation">[[Players are required to “explain their viewpoint clearly and concisely” and “resolve disputes as quickly as possible.” As such, most discussions should not exceed thirty seconds before either reaching a resolution or requesting an observer to resolve the dispute. If both players have had an opportunity to state their viewpoint and it is clear that an agreement will not be reached, players have an obligation to accept that the call is contested and resolve it as such. Where a dispute exists regarding what a rule says, the players may agree to consult a rulebook.]]</div>
                 </li>
                 <li>
-                    <a id="2.E"></a>The following are examples of actions to support good spirit. While the absence of these actions is not necessarily an indication of poor spirit, the examples illustrate three core tenets of Spirit of the Game &mdash; mutual respect, adherence to the rules, and the basic joy of play:
-                    <ol>
-                        <li><a id="2.E.1"></a>playing safely by actively avoiding unnecessary body contact;</li>
-                        <li><a id="2.E.2"></a>working as a team to ensure that all players have an excellent knowledge of the rules;</li>
-                        <li><a id="2.E.3"></a>bringing up spirit issues with opponents as early as possible;</li>
-                        <li><a id="2.E.4"></a>establishing lines of communication to address spirit and safety issues (e.g. <span class="tooltip" title="A team member, who is eligible to participate in the game, and has been designated to address, discuss, and resolve spirit issues at any point throughout the competition with their opponents, teammates, coaches, and game or event officials.">spirit captain</span> pregame and halftime meetings; calling a spirit timeout if needed);</li>
-                        <li><a id="2.E.5"></a>informing a teammate if they have made a wrong or unnecessary call, caused a foul or violation, or need a clarification of a rule;</li>
-                        <li><a id="2.E.6"></a>retracting a call when you no longer believe the call was necessary or believe that it was made in error and should not have been called;</li>
-                        <li><a id="2.E.7"></a>celebrating exciting plays and good spirit by both teams;</li>
-                        <li><a id="2.E.8"></a>touching base with an opponent on the sideline after a contentious interaction;</li>
-                        <li><a id="2.E.9"></a>discussing and/or making calls about contact that could be considered a foul in order to keep players safe;</li>
-                        <li><a id="2.E.10"></a>connecting with or introducing yourself to an opponent on the sideline;</li>
-                        <li><a id="2.E.11"></a>keeping communication open and engaging in a way that seeks to de-escalate disputed situations; and</li>
-                        <li><a id="2.E.12"></a>participating in a pre- or post-game spirit circle that includes spirit highlights and constructive spirit feedback (if needed) for each team;</li>
-                    </ol>
+                    <a id="2.E">2.E.</a> The following are examples of actions to support good spirit. While the absence of these actions is not necessarily an indication of poor spirit, the examples illustrate three core tenets of Spirit of the Game &mdash; mutual respect, adherence to the rules, and the basic joy of play:
+                    <ul>
+                        <li><a id="2.E.1">2.E.1.</a> playing safely by actively avoiding unnecessary body contact;</li>
+                        <li><a id="2.E.2">2.E.2.</a> working as a team to ensure that all players have an excellent knowledge of the rules;</li>
+                        <li><a id="2.E.3">2.E.3.</a> bringing up spirit issues with opponents as early as possible;</li>
+                        <li><a id="2.E.4">2.E.4.</a> establishing lines of communication to address spirit and safety issues (e.g. <span class="tooltip" title="A team member, who is eligible to participate in the game, and has been designated to address, discuss, and resolve spirit issues at any point throughout the competition with their opponents, teammates, coaches, and game or event officials.">spirit captain</span> pregame and halftime meetings; calling a spirit timeout if needed);</li>
+                        <li><a id="2.E.5">2.E.5.</a> informing a teammate if they have made a wrong or unnecessary call, caused a foul or violation, or need a clarification of a rule;</li>
+                        <li><a id="2.E.6">2.E.6.</a> retracting a call when you no longer believe the call was necessary or believe that it was made in error and should not have been called;</li>
+                        <li><a id="2.E.7">2.E.7.</a> celebrating exciting plays and good spirit by both teams;</li>
+                        <li><a id="2.E.8">2.E.8.</a> touching base with an opponent on the sideline after a contentious interaction;</li>
+                        <li><a id="2.E.9">2.E.9.</a> discussing and/or making calls about contact that could be considered a foul in order to keep players safe;</li>
+                        <li><a id="2.E.10">2.E.10.</a> connecting with or introducing yourself to an opponent on the sideline;</li>
+                        <li><a id="2.E.11">2.E.11.</a> keeping communication open and engaging in a way that seeks to de-escalate disputed situations; and</li>
+                        <li><a id="2.E.12">2.E.12.</a> participating in a pre- or post-game spirit circle that includes spirit highlights and constructive spirit feedback (if needed) for each team;</li>
+                    </ul>
                 </li>
 
                 <li>
-                    <a id="2.F"></a>The following actions are clear violations of the Spirit of the Game and must be avoided by all participants:
-                    <ol>
-                        <li><a id="2.F.1"></a>reckless play or dangerously aggressive behavior;</li>
-                        <li><a id="2.F.2"></a>intentional fouling or other intentional rule violations;</li>
-                        <li><a id="2.F.3"></a>taunting or intimidating opposing players;</li>
-                        <li><a id="2.F.4"></a>celebration that is targeted towards an opponent in a negative or aggressive manner;</li>
-                        <li><a id="2.F.5"></a>intentionally damaging equipment;</li>
-                        <li><a id="2.F.6"></a>making calls in retaliation to an opponent's calls or other actions;</li>
-                        <li><a id="2.F.7"></a>allowing preconceived expectations, biases (e.g., microaggressions), or previous interactions or encounters with a player or team to affect how game situations are reacted to and judged;</li>
-                        <li><a id="2.F.8"></a>calling for a pass from an opponent; and</li>
-                        <li><a id="2.F.9"></a>other win-at-all-costs behavior.</li>
-                    </ol>
+                    <a id="2.F">2.F.</a> The following actions are clear violations of the Spirit of the Game and must be avoided by all participants:
+                    <ul>
+                        <li><a id="2.F.1">2.F.1.</a> reckless play or dangerously aggressive behavior;</li>
+                        <li><a id="2.F.2">2.F.2.</a> intentional fouling or other intentional rule violations;</li>
+                        <li><a id="2.F.3">2.F.3.</a> taunting or intimidating opposing players;</li>
+                        <li><a id="2.F.4">2.F.4.</a> celebration that is targeted towards an opponent in a negative or aggressive manner;</li>
+                        <li><a id="2.F.5">2.F.5.</a> intentionally damaging equipment;</li>
+                        <li><a id="2.F.6">2.F.6.</a> making calls in retaliation to an opponent's calls or other actions;</li>
+                        <li><a id="2.F.7">2.F.7.</a> allowing preconceived expectations, biases (e.g., microaggressions), or previous interactions or encounters with a player or team to affect how game situations are reacted to and judged;</li>
+                        <li><a id="2.F.8">2.F.8.</a> calling for a pass from an opponent; and</li>
+                        <li><a id="2.F.9">2.F.9.</a> other win-at-all-costs behavior.</li>
+                    </ul>
                 </li>
 
                 <li>
-                    <a id="2.G"></a>Teams are guardians of the Spirit of the Game, and must:
-                    <ol>
-                        <li><a id="2.G.1"></a>take responsibility for teaching their players the rules and good spirit;</li>
+                    <a id="2.G">2.G.</a> Teams are guardians of the Spirit of the Game, and must:
+                    <ul>
+                        <li><a id="2.G.1">2.G.1.</a> take responsibility for teaching their players the rules and good spirit;</li>
                         <li>
-                            <a id="2.G.2"></a>discipline
+                            <a id="2.G.2">2.G.2.</a> discipline
                             <span class="tooltip" title="Any person designated by the team, to the event organizer, to be officially associated with the team, per the rules established by the event organizer.">team members</span>
                             who display poor spirit;
                         </li>
-                        <li><a id="2.G.3"></a>provide constructive feedback to other teams about what they are doing well and/or how to improve their adherence to the Spirit of the Game; and</li>
+                        <li><a id="2.G.3">2.G.3.</a> provide constructive feedback to other teams about what they are doing well and/or how to improve their adherence to the Spirit of the Game; and</li>
                         <li>
-                            <a id="2.G.4"></a>be aware regarding the potential for implicit biases to impact play and Spirit of the Game.
-                            <ol>
-                                <li><a id="2.G.4.a"></a>Players and team leaders should acknowledge and recognize that the implementation of Spirit of the Game (SOTG) is susceptible to bias. Team leaders should be mindful of and encourage their teammates to be mindful of their own biases when considering and discussing interactions with, and impressions of, other teams as well as their own team. Understand that intent and impact are not the same. The intent of a person's statement or gesture may be neutral or positive to them, but the impact of what they say or do may be harmful or hurtful to others.</li>
-                            </ol>
+                            <a id="2.G.4">2.G.4.</a> be aware regarding the potential for implicit biases to impact play and Spirit of the Game.
+                            <ul>
+                                <li><a id="2.G.4.a">2.G.4.a.</a> Players and team leaders should acknowledge and recognize that the implementation of Spirit of the Game (SOTG) is susceptible to bias. Team leaders should be mindful of and encourage their teammates to be mindful of their own biases when considering and discussing interactions with, and impressions of, other teams as well as their own team. Understand that intent and impact are not the same. The intent of a person's statement or gesture may be neutral or positive to them, but the impact of what they say or do may be harmful or hurtful to others.</li>
+                            </ul>
                         </li>
-                    </ol>
+                    </ul>
                 </li>
 
                 <li>
-                    <a id="2.H"></a>In the case where a novice player commits an infraction out of ignorance of the rules, experienced players are obliged to explain the infraction and clarify what should happen.
-                    <ol>
-                        <li><a id="2.H.1"></a><span class="tooltip" title="A team member who has been officially recognized by event organizers to have met the requirements necessary for coaching, including but not limited to certification, screening, education, and registration. Coaches are permitted in areas where sideline players are allowed, during and between points, in accordance with event rules. Coaches are not permitted to make calls or contribute to the discussion or resolution of calls, except to clarify rules if requested.">Coaches</span> should teach players to come to a resolution on their own. Coaches may not make calls from the sideline nor offer their opinion on a play. If asked during a dispute coaches may offer rules clarifications. After a dispute, and when the player is not playing, a coach may talk to their own player about the dispute and offer opinions and guidance.</li>
-                    </ol>
+                    <a id="2.H">2.H.</a> In the case where a novice player commits an infraction out of ignorance of the rules, experienced players are obliged to explain the infraction and clarify what should happen.
+                    <ul>
+                        <li><a id="2.H.1">2.H.1.</a> <span class="tooltip" title="A team member who has been officially recognized by event organizers to have met the requirements necessary for coaching, including but not limited to certification, screening, education, and registration. Coaches are permitted in areas where sideline players are allowed, during and between points, in accordance with event rules. Coaches are not permitted to make calls or contribute to the discussion or resolution of calls, except to clarify rules if requested.">Coaches</span> should teach players to come to a resolution on their own. Coaches may not make calls from the sideline nor offer their opinion on a play. If asked during a dispute coaches may offer rules clarifications. After a dispute, and when the player is not playing, a coach may talk to their own player about the dispute and offer opinions and guidance.</li>
+                    </ul>
                 </li>
 
                 <li>
-                    <a id="2.I"></a>Rules should be interpreted by the players directly involved in the play, or by players who had the
+                    <a id="2.I">2.I.</a> Rules should be interpreted by the players directly involved in the play, or by players who had the
                     <span class="tooltip" title="The most complete view available by a player that includes the relative positions of the disc, ground, players, and line markers involved in a play. On an unlined field, this may require sighting from one field marker to another.">best perspective</span>
                     on the play (<a href="https://usaultimate.org/rules/#3.A">3.A</a>). Players may seek the perspective of
                     <span class="tooltip" title="Any team member who is present at the field and eligible to participate in the game, but who is not a player participating in the current point.">sideline players</span>
                     to clarify the rules, and to assist in making the appropriate call (<a href="https://usaultimate.org/rules/#3.A.1">3.A.1</a>, <a href="https://usaultimate.org/rules/#3.A.1.a">3.A.1.a</a>). Sideline players should not interject unless their input is requested. <span class="annotation">[[It is acceptable for sideline players to state that they have input, but they should avoid interjecting unless requested.]]</span>
                 </li>
                 <li>
-                    <a id="2.J"></a>Players are responsible for making all calls except where specific rules designate
+                    <a id="2.J">2.J.</a> Players are responsible for making all calls except where specific rules designate
                     <span class="tooltip" title="Any person who is not a player or sideline player as defined in these rules.">non-players</span>
                     to make calls.
                     <span class="annotation"
@@ -188,156 +193,156 @@
                     >
                 </li>
                 <li>
-                    <a id="2.K"></a>If after discussion players cannot agree, or it is unclear:
-                    <ol>
-                        <li><a id="2.K.1"></a>what occurred in a play, or</li>
-                        <li><a id="2.K.2"></a>what would most likely have occurred in a play,</li>
-                    </ol>
+                    <a id="2.K">2.K.</a> If after discussion players cannot agree, or it is unclear:
+                    <ul>
+                        <li><a id="2.K.1">2.K.1.</a> what occurred in a play, or</li>
+                        <li><a id="2.K.2">2.K.2.</a> what would most likely have occurred in a play,</li>
+                    </ul>
 
                     the disc is returned to the thrower.
                 </li>
-            </ol>
+            </ul>
         </li>
 
         <li>
-            <a id="3"></a>Definitions
-            <ol>
+            <a id="3">3.</a> Definitions
+            <ul>
                 <li>
-                    <a id="3.A"></a>Best perspective: The most complete view available by a <span class="tooltip" title="One of the up to fourteen (14) persons who are participating in the current point of play.">player</span> that includes the relative positions of the disc, ground, players, and line markers involved in a play. On an unlined field, this may require sighting from one field marker to another. Best perspective always belongs to a player. However, players may rely on the following sources as a component of best perspective:
-                    <ol>
+                    <a id="3.A">3.A.</a> Best perspective: The most complete view available by a <span class="tooltip" title="One of the up to fourteen (14) persons who are participating in the current point of play.">player</span> that includes the relative positions of the disc, ground, players, and line markers involved in a play. On an unlined field, this may require sighting from one field marker to another. Best perspective always belongs to a player. However, players may rely on the following sources as a component of best perspective:
+                    <ul>
                         <li>
-                            <a id="3.A.1"></a>Players may seek the perspective of
+                            <a id="3.A.1">3.A.1.</a> Players may seek the perspective of
                             <span class="tooltip" title="Any team member who is present at the field and eligible to participate in the game, but who is not a player participating in the current point.">sideline players</span>
                             to clarify the rules and to assist players in making the appropriate call. Players may seek the perspective of
                             <span class="tooltip" title="A team member who has been officially recognized by event organizers to have met the requirements necessary for coaching, including but not limited to certification, screening, education, and registration. Coaches are permitted in areas where sideline players are allowed, during and between points, in accordance with event rules. Coaches are not permitted to make calls or contribute to the discussion or resolution of calls, except to clarify rules if requested.">coaches</span>
                             to clarify a rule, but not to assist in making the appropriate call.
-                            <ol>
+                            <ul>
                                 <li>
-                                    <a id="3.A.1.a"></a><span class="tooltip" title="Any team member who is present at the field and eligible to participate in the game, but who is not a player participating in the current point.">Sideline players</span>
+                                    <a id="3.A.1.a">3.A.1.a.</a> <span class="tooltip" title="Any team member who is present at the field and eligible to participate in the game, but who is not a player participating in the current point.">Sideline players</span>
                                     should not offer their perspective unless solicited by a player. However, a sideline player may offer perspective without being asked by a player if the perspective offered is to the detriment of the sideline player's team.
                                 </li>
-                            </ol>
+                            </ul>
                         </li>
 
                         <li>
-                            <a id="3.A.2"></a>Players may review officially-designated video footage to assist in resolving a call where such footage is available. However, play may not be delayed to review video footage.
+                            <a id="3.A.2">3.A.2.</a> Players may review officially-designated video footage to assist in resolving a call where such footage is available. However, play may not be delayed to review video footage.
                             <span class="annotation">[[For example, live instant replay in a stadium setting may be used by players to resolve a contested foul call. Players may not, however, request that a particular play be replayed on the screen. If, after reviewing the video, players still cannot agree, they should not delay the game to rewatch the play multiple times; instead, the play should be treated as a regular contested foul.]]</span>
                         </li>
-                    </ol>
+                    </ul>
 
                     If no player has sufficient perspective to make a call, the disc should revert to the thrower (in the case of in-bounds/out-of-bounds and up/down disputes) or remain with the receiver on the end zone line (in the case of goal/non-goal disputes).
                 </li>
 
-                <li><a id="3.B"></a>Completed pass: Any catch that results in the team in possession of the disc retaining possession. Any pass that is not complete is incomplete.</li>
-                <li><a id="3.C"></a>Foul: Non-Incidental contact between opposing players (see <a href="https://usaultimate.org/rules/#3.F">3.F</a> for a definition of incidental contact). In general, the player initiating the contact has committed the foul.</li>
-                <li><a id="3.D"></a>Ground contact: All player contact with the ground directly related to a specific event or maneuver (e.g., jumping, diving, leaning or falling), including landing or recovering after being off-balance. Items on the ground are considered part of the ground.</li>
+                <li><a id="3.B">3.B.</a> Completed pass: Any catch that results in the team in possession of the disc retaining possession. Any pass that is not complete is incomplete.</li>
+                <li><a id="3.C">3.C.</a> Foul: Non-Incidental contact between opposing players (see <a href="https://usaultimate.org/rules/#3.F">3.F</a> for a definition of incidental contact). In general, the player initiating the contact has committed the foul.</li>
+                <li><a id="3.D">3.D.</a> Ground contact: All player contact with the ground directly related to a specific event or maneuver (e.g., jumping, diving, leaning or falling), including landing or recovering after being off-balance. Items on the ground are considered part of the ground.</li>
                 <li>
-                    <a id="3.E"></a>Guarding: A defender is guarding an
+                    <a id="3.E">3.E.</a> Guarding: A defender is guarding an
                     <span class="tooltip" title="A player whose team is in possession of the disc.">offensive player</span>
                     when they are within 10 feet of that offensive player and are reacting to that offensive player.
                     <span class="annotation">[[A defender who turns away from an offensive player and begins focusing on and reacting to the thrower is no longer guarding that offensive player.]]</span>
                 </li>
                 <li>
-                    <a id="3.F"></a>Incidental contact: Contact between opposing players that does not affect continued play.
+                    <a id="3.F">3.F.</a> Incidental contact: Contact between opposing players that does not affect continued play.
                     <span class="annotation">[[For example, contact affects continued play if the contact knocks a player off-balance and interferes with their ability to continue cutting or playing defense.]]</span>
                 </li>
                 <li>
-                    <a id="3.G"></a>Legal position: A position established by a
+                    <a id="3.G">3.G.</a> Legal position: A position established by a
                     <span class="tooltip" title="The defensive player within ten feet of the thrower&#39;s pivot or of the thrower if no pivot has been established. If the disc is not in a player&#39;s possession, a defensive player within ten feet of a spot on the field where the disc is to be put into play is considered the marker.">marker</span>
                     that does not violate any of the provisions outlined in
                     <a href="https://usaultimate.org/rules/#15.B">15.B</a>.
                     <span class="annotation">[[This refers to legal marking position. In general, this means there is sufficient space between the marker and the thrower's torso, the marker is not straddling the pivot, and the marker's arms are not “wrapping” the thrower.]]</span>
                 </li>
-                <li><a id="3.H"></a>Line: A boundary defining the playing areas. On an unlined field, the boundary is an imaginary line segment between two field markers with the thickness of said markers. Line segments are not extrapolated beyond the defining markers.</li>
+                <li><a id="3.H">3.H.</a> Line: A boundary defining the playing areas. On an unlined field, the boundary is an imaginary line segment between two field markers with the thickness of said markers. Line segments are not extrapolated beyond the defining markers.</li>
                 <li>
-                    <a id="3.I"></a>Pivot: The particular part of the body in continuous contact with a single spot on the field during a thrower's possession once the thrower has come to a stop or has attempted a throw or fake. When there is a definitive spot for putting the disc into play, the part of the body in contact with that spot is the pivot.
+                    <a id="3.I">3.I.</a> Pivot: The particular part of the body in continuous contact with a single spot on the field during a thrower's possession once the thrower has come to a stop or has attempted a throw or fake. When there is a definitive spot for putting the disc into play, the part of the body in contact with that spot is the pivot.
                     <span class="annotation">[[This is not a body part, but rather an infinitesimally small point on the body.]]</span>
                 </li>
                 <li>
-                    <a id="3.J"></a>Possession of the disc: Sustained contact with, and control of, a non-spinning disc.
-                    <ol>
-                        <li><a id="3.J.1"></a>Catching a pass is equivalent to establishing possession of that pass.</li>
+                    <a id="3.J">3.J.</a> Possession of the disc: Sustained contact with, and control of, a non-spinning disc.
+                    <ul>
+                        <li><a id="3.J.1">3.J.1.</a> Catching a pass is equivalent to establishing possession of that pass.</li>
                         <li>
-                            <a id="3.J.2"></a>If a player loses possession of a disc during movement related to a catch, the initial possession ends.
+                            <a id="3.J.2">3.J.2.</a> If a player loses possession of a disc during movement related to a catch, the initial possession ends.
                             <span class="annotation">[[A disc that touches the ground while in a player's possession is not a turnover.]]</span>
                         </li>
-                        <li><a id="3.J.3"></a>On a throw, the thrower's possession ends when they are no longer in contact with the disc.</li>
+                        <li><a id="3.J.3">3.J.3.</a> On a throw, the thrower's possession ends when they are no longer in contact with the disc.</li>
                         <li>
-                            <a id="3.J.4"></a>A disc in a player's possession is considered part of that player.
+                            <a id="3.J.4">3.J.4.</a> A disc in a player's possession is considered part of that player.
                             <span class="annotation">[[Thus, hitting the disc in a player's possession is a foul]]</span>
                         </li>
-                        <li><a id="3.J.5"></a>The team whose player is in possession, or whose players may pick up the disc, is considered the team in possession. If the disc is in the air following a legal pass, the thrower's team is considered the team in possession.</li>
-                    </ol>
+                        <li><a id="3.J.5">3.J.5.</a> The team whose player is in possession, or whose players may pick up the disc, is considered the team in possession. If the disc is in the air following a legal pass, the thrower's team is considered the team in possession.</li>
+                    </ul>
                 </li>
 
                 <li>
-                    <a id="3.K"></a>Pull: The throw from one team to the other that starts play at the beginning of a half or after a goal. It is not a legal pass for scoring and has many special provisions (Section <a href="https://usaultimate.org/rules/#9.B">9.B</a>). The player on the pulling team who possesses the disc and signals readiness is the puller.
+                    <a id="3.K">3.K.</a> Pull: The throw from one team to the other that starts play at the beginning of a half or after a goal. It is not a legal pass for scoring and has many special provisions (Section <a href="https://usaultimate.org/rules/#9.B">9.B</a>). The player on the pulling team who possesses the disc and signals readiness is the puller.
                     <span class="annotation">[[The pulling team may designate a new puller at any time before the pull.]]</span>
                 </li>
-                <li><a id="3.L"></a>Scoring attempt: A scoring attempt starts at the beginning of the game or when the previous goal is scored and ends when the next goal is scored.</li>
+                <li><a id="3.L">3.L.</a> Scoring attempt: A scoring attempt starts at the beginning of the game or when the previous goal is scored and ends when the next goal is scored.</li>
                 <li>
-                    <a id="3.M"></a>State of the disc: The nature of play at a particular moment during the game. There are three states of the disc:
-                    <ol>
+                    <a id="3.M">3.M.</a> State of the disc: The nature of play at a particular moment during the game. There are three states of the disc:
+                    <ul>
                         <li>
-                            <a id="3.M.1"></a>A disc is “in play” when players are allowed to move and play may proceed without the defense's acknowledgment. An in-bounds disc in the central zone is in play. The disc is subject to a turnover. If no player has
+                            <a id="3.M.1">3.M.1.</a> A disc is “in play” when players are allowed to move and play may proceed without the defense's acknowledgment. An in-bounds disc in the central zone is in play. The disc is subject to a turnover. If no player has
                             <span class="tooltip" title="Sustained contact with, and control of, a non-spinning disc.">possession</span>
                             of a disc in play, any
                             <span class="tooltip" title="A player whose team is in possession of the disc.">offensive player</span>
                             may become the thrower by taking possession of the disc (<a href="https://usaultimate.org/rules/#14.A">14.A</a>). Once a player has possession of the disc, they must establish a pivot at the spot of the disc <a href="https://usaultimate.org/rules/#14.A.2">14.A.2</a>) prior to attempting a pass (<a href="https://usaultimate.org/rules/#17.K">17.K</a>).
                         </li>
-                        <li><a id="3.M.2"></a>A disc is “live” when players are allowed to move and the disc is subject to a turnover, but the thrower cannot make a legal pass (e.g., walking the disc to the spot where it is to be put into play). For a live disc to be put into play, the thrower must (1) establish a pivot at the appropriate spot on the field, and (2) touch the disc to the ground (<a href="https://usaultimate.org/rules/#14.B">14.B</a>).</li>
+                        <li><a id="3.M.2">3.M.2.</a> A disc is “live” when players are allowed to move and the disc is subject to a turnover, but the thrower cannot make a legal pass (e.g., walking the disc to the spot where it is to be put into play). For a live disc to be put into play, the thrower must (1) establish a pivot at the appropriate spot on the field, and (2) touch the disc to the ground (<a href="https://usaultimate.org/rules/#14.B">14.B</a>).</li>
                         <li>
-                            <a id="3.M.3"></a>A disc is “dead” when play has stopped and can continue only with a check (see <a href="https://usaultimate.org/rules/#9.D">9.D</a>). The disc is not subject to a turnover. A dead disc may change states to either
+                            <a id="3.M.3">3.M.3.</a> A disc is “dead” when play has stopped and can continue only with a check (see <a href="https://usaultimate.org/rules/#9.D">9.D</a>). The disc is not subject to a turnover. A dead disc may change states to either
                             <span class="tooltip" title="A disc is live when players are allowed to move and the disc is subject to a turnover, but the thrower cannot make a legal pass (e.g., walking the disc to the spot where it is to be put into play). For a live disc to be put into play, the thrower must (1) establish a pivot at the appropriate spot on the field, and (2) touch the disc to the ground (14.B).">live</span>
                             or
                             <span class="tooltip" title="A disc is in play when players are allowed to move and play may proceed without the defense&#39;s acknowledgment. An in-bounds disc in the central zone is in play. The disc is subject to a turnover. If no player has possession of a disc in play, any offensive player may become the thrower by taking possession of the disc (14.A). Once a player has possession of the disc, they must establish a pivot at the spot of the disc 14.A.2) prior to attempting a pass (17.K).">in play</span>
                             after a check depending on the circumstances.
                         </li>
-                    </ol>
+                    </ul>
                 </li>
 
                 <li>
-                    <a id="3.N"></a>Stoppage of play: Any halting of play due to a call, discussion, or timeout that requires a check or self-check to restart play. The term play stops means a stoppage of play occurs.
+                    <a id="3.N">3.N.</a> Stoppage of play: Any halting of play due to a call, discussion, or timeout that requires a check or self-check to restart play. The term play stops means a stoppage of play occurs.
                     <span class="annotation">[[Play-halting calls include “foul,” “violation,” “pick,” “stall,” etc.]]</span>
                 </li>
                 <li>
-                    <a id="3.O"></a>A disc in flight following any throwing motion (including a fake) that results in the thrower losing contact with the disc.
+                    <a id="3.O">3.O.</a> A disc in flight following any throwing motion (including a fake) that results in the thrower losing contact with the disc.
                     <span class="annotation">[[Generally, a non-spinning, falling disc is not “in flight” unless it is intentionally dropped.]]</span>
-                    <ol>
-                        <li><a id="3.O.1"></a>A pass is equivalent to a throw.</li>
-                        <li><a id="3.O.2"></a>An intentionally dropped disc is considered a thrown disc.</li>
-                        <li><a id="3.O.3"></a>The act of throwing is the motion that transfers momentum from the thrower to the disc in the direction of flight and results in a throw. Pivots and wind-ups are not part of the act of throwing.</li>
+                    <ul>
+                        <li><a id="3.O.1">3.O.1.</a> A pass is equivalent to a throw.</li>
+                        <li><a id="3.O.2">3.O.2.</a> An intentionally dropped disc is considered a thrown disc.</li>
+                        <li><a id="3.O.3">3.O.3.</a> The act of throwing is the motion that transfers momentum from the thrower to the disc in the direction of flight and results in a throw. Pivots and wind-ups are not part of the act of throwing.</li>
                         <li>
-                            <a id="3.O.4"></a>A throw is only considered complete when an
+                            <a id="3.O.4">3.O.4.</a> A throw is only considered complete when an
                             <span class="tooltip" title="A player whose team is in possession of the disc.">offensive player</span>
                             gains
                             <span class="tooltip" title="Sustained contact with, and control of, a non-spinning disc.">possession</span>
                             that is not otherwise negated.
                         </li>
                         <li>
-                            <a id="3.O.5"></a>An
+                            <a id="3.O.5">3.O.5.</a> An
                             <span class="tooltip" title="A player whose team is in possession of the disc.">offensive player</span>
                             in
                             <span class="tooltip" title="Sustained contact with, and control of, a non-spinning disc.">possession</span>
                             of, or who has most recently possessed, the disc, is the thrower.
                         </li>
-                    </ol>
+                    </ul>
                 </li>
 
-                <li><a id="3.P"></a>Violation: Any infraction of the rules other than a foul.</li>
+                <li><a id="3.P">3.P.</a> Violation: Any infraction of the rules other than a foul.</li>
                 <li>
-                    <a id="3.Q"></a>Roles
-                    <ol>
-                        <li><a id="3.Q.1"></a>Captain: A team member, who is eligible to participate in the game, and has been designated to represent the team in decision-making on behalf of the team before, during, and after a game.</li>
+                    <a id="3.Q">3.Q.</a> Roles
+                    <ul>
+                        <li><a id="3.Q.1">3.Q.1.</a> Captain: A team member, who is eligible to participate in the game, and has been designated to represent the team in decision-making on behalf of the team before, during, and after a game.</li>
                         <li>
-                            <a id="3.Q.2"></a>Coach: A team member who has been officially recognized by
+                            <a id="3.Q.2">3.Q.2.</a> Coach: A team member who has been officially recognized by
                             <span class="tooltip" title="The person(s) or entity organizing and responsible for a competition, whether it is a tournament, tournament series, league, single game, or other type of event. Responsibilities may include, but are not limited to competition rules, safety, event registration and event logistics.">event organizers</span>
                             to have met the requirements necessary for coaching, including but not limited to certification, screening, education, and registration. Coaches are permitted in areas where
                             <span class="tooltip" title="Any team member who is present at the field and eligible to participate in the game, but who is not a player participating in the current point.">sideline players</span>
                             are allowed, during and between points, in accordance with event rules. Coaches are not permitted to make calls or contribute to the discussion or resolution of calls, except to clarify rules if requested.
                         </li>
                         <li>
-                            <a id="3.Q.3"></a>Defensive player/Defender: A player whose team is not in
+                            <a id="3.Q.3">3.Q.3.</a> Defensive player/Defender: A player whose team is not in
                             <span class="tooltip" title="Sustained contact with, and control of, a non-spinning disc.">possession</span>
                             of the disc. A defensive player may not pick up a
                             <span class="tooltip" title="A disc is live when players are allowed to move and the disc is subject to a turnover, but the thrower cannot make a legal pass (e.g., walking the disc to the spot where it is to be put into play). For a live disc to be put into play, the thrower must (1) establish a pivot at the appropriate spot on the field, and (2) touch the disc to the ground (14.B).">live</span>
@@ -345,531 +350,531 @@
                             <span class="tooltip" title="A disc is in play when players are allowed to move and play may proceed without the defense&#39;s acknowledgment. An in-bounds disc in the central zone is in play. The disc is subject to a turnover. If no player has possession of a disc in play, any offensive player may become the thrower by taking possession of the disc (14.A). Once a player has possession of the disc, they must establish a pivot at the spot of the disc 14.A.2) prior to attempting a pass (17.K).">in play</span>
                             or call for a pass from the thrower.
                         </li>
-                        <li><a id="3.Q.4"></a>Event organizer: The person(s) or entity organizing and responsible for a competition, whether it is a tournament, tournament series, league, single game, or other type of event. Responsibilities may include, but are not limited to competition rules, safety, event registration and event logistics.</li>
-                        <li><a id="3.Q.5"></a>Event support staff: Event support staff are officially designated personnel assigned by the event organizers to cover a wide variety of positions and responsibilities associated with an event, including but not limited to medical staff, scorekeepers, security, media, field crew, and other paid or volunteer positions. Vendors, sponsors, and business partners may also be designated as event support staff by the event organizer. Event support staff do not have additional duties or permissions beyond those specifically assigned by the event organizer.</li>
+                        <li><a id="3.Q.4">3.Q.4.</a> Event organizer: The person(s) or entity organizing and responsible for a competition, whether it is a tournament, tournament series, league, single game, or other type of event. Responsibilities may include, but are not limited to competition rules, safety, event registration and event logistics.</li>
+                        <li><a id="3.Q.5">3.Q.5.</a> Event support staff: Event support staff are officially designated personnel assigned by the event organizers to cover a wide variety of positions and responsibilities associated with an event, including but not limited to medical staff, scorekeepers, security, media, field crew, and other paid or volunteer positions. Vendors, sponsors, and business partners may also be designated as event support staff by the event organizer. Event support staff do not have additional duties or permissions beyond those specifically assigned by the event organizer.</li>
                         <li>
-                            <a id="3.Q.6"></a>Marker: The
+                            <a id="3.Q.6">3.Q.6.</a> Marker: The
                             <span class="tooltip" title="A player whose team is not in possession of the disc. A defensive player may not pick up a live disc or a disc in play or call for a pass from the thrower.">defensive player</span>
                             within ten feet of the thrower's pivot or of the thrower if no pivot has been established. If the disc is not in a player's possession, a defensive player within ten feet of a spot on the field where the disc is to be put into play is considered the marker.
                         </li>
                         <li>
-                            <a id="3.Q.7"></a>Non-player: Any person who is not a player or
+                            <a id="3.Q.7">3.Q.7.</a> Non-player: Any person who is not a player or
                             <span class="tooltip" title="Any team member who is present at the field and eligible to participate in the game, but who is not a player participating in the current point.">sideline player</span>
                             as defined in these rules.
                         </li>
                         <li>
-                            <a id="3.Q.8"></a>Observer: Observers are
+                            <a id="3.Q.8">3.Q.8.</a> Observer: Observers are
                             <span class="tooltip" title="Any person who is not a player or sideline player as defined in these rules.">non-player</span>
                             game officials whose job is to support the players in implementing a safe, fair, and efficient game. Observers carefully watch the action of the game, assist with communication, help uphold self-officiating and the Spirit of the Game, assist with resolving calls as needed, and perform other duties as described in Section <a href="https://usaultimate.org/rules/#19">19</a>.
                         </li>
-                        <li><a id="3.Q.9"></a>Offensive player: A player whose team is in possession of the disc.</li>
-                        <li><a id="3.Q.10"></a>Player: One of the up to fourteen (14) persons who are participating in the current point of play.</li>
+                        <li><a id="3.Q.9">3.Q.9.</a> Offensive player: A player whose team is in possession of the disc.</li>
+                        <li><a id="3.Q.10">3.Q.10.</a> Player: One of the up to fourteen (14) persons who are participating in the current point of play.</li>
                         <li>
-                            <a id="3.Q.11"></a>Sideline player: Any
+                            <a id="3.Q.11">3.Q.11.</a> Sideline player: Any
                             <span class="tooltip" title="Any person designated by the team, to the event organizer, to be officially associated with the team, per the rules established by the event organizer.">team member</span>
                             who is present at the field and eligible to participate in the game, but who is not a player participating in the current point.
                         </li>
                         <li>
-                            <a id="3.Q.12"></a>Spectator: Event attendees who do not fall into one of the other roles defined in
+                            <a id="3.Q.12">3.Q.12.</a> Spectator: Event attendees who do not fall into one of the other roles defined in
                             <a href="https://usaultimate.org/rules/#3.Q">3.Q.</a>
                         </li>
                         <li>
-                            <a id="3.Q.13"></a>Spirit captain: A <span class="tooltip" title="Any person designated by the team, to the event organizer, to be officially associated with the team, per the rules established by the event organizer.">team member</span>, who is eligible to participate in the game, and has been designated to address, discuss, and resolve spirit issues at any point throughout the competition with opponents, teammates, <span class="tooltip" title="A team member who has been officially recognized by event organizers to have met the requirements necessary for coaching, including but not limited to certification, screening, education, and registration. Coaches are permitted in areas where sideline players are allowed, during and between points, in accordance with event rules. Coaches are not permitted to make calls or contribute to the discussion or resolution of calls, except to clarify rules if requested.">coaches</span>, and game or event officials. If no
+                            <a id="3.Q.13">3.Q.13.</a> Spirit captain: A <span class="tooltip" title="Any person designated by the team, to the event organizer, to be officially associated with the team, per the rules established by the event organizer.">team member</span>, who is eligible to participate in the game, and has been designated to address, discuss, and resolve spirit issues at any point throughout the competition with opponents, teammates, <span class="tooltip" title="A team member who has been officially recognized by event organizers to have met the requirements necessary for coaching, including but not limited to certification, screening, education, and registration. Coaches are permitted in areas where sideline players are allowed, during and between points, in accordance with event rules. Coaches are not permitted to make calls or contribute to the discussion or resolution of calls, except to clarify rules if requested.">coaches</span>, and game or event officials. If no
                             spirit captain is designated, this role is assigned to the <span class="tooltip" title="A team member, who is eligible to participate in the game, and has been designated to represent the team in decision-making on behalf of the team before, during, and after a game.">captain(s)</span>.
                         </li>
-                        <li><a id="3.Q.14"></a>Team member: Any person designated by the team, to the event organizer, to be officially associated with the team, per the rules established by the <span class="tooltip" title="The person(s) or entity organizing and responsible for a competition, whether it is a tournament, tournament series, league, single game, or other type of event. Responsibilities may include, but are not limited to competition rules, safety, event registration and event logistics.">event organizer</span>.</li>
+                        <li><a id="3.Q.14">3.Q.14.</a> Team member: Any person designated by the team, to the event organizer, to be officially associated with the team, per the rules established by the <span class="tooltip" title="The person(s) or entity organizing and responsible for a competition, whether it is a tournament, tournament series, league, single game, or other type of event. Responsibilities may include, but are not limited to competition rules, safety, event registration and event logistics.">event organizer</span>.</li>
                         <li>
-                            <a id="3.Q.15"></a>Team support staff: A
+                            <a id="3.Q.15">3.Q.15.</a> Team support staff: A
                             <span class="tooltip" title="Any person designated by the team, to the event organizer, to be officially associated with the team, per the rules established by the event organizer.">team member</span>
                             who has been officially recognized by event organizers to be a member of the team for a specific support purpose. Team support staff are generally permitted in areas where
                             <span class="tooltip" title="Any team member who is present at the field and eligible to participate in the game, but who is not a player participating in the current point.">sideline players</span>
                             are allowed, but may be further restricted by event rules.
                         </li>
-                    </ol>
+                    </ul>
                 </li>
-            </ol>
+            </ul>
         </li>
 
         <li>
-            <a id="4"></a>Playing Field
-            <ol>
-                <li><a id="4.A"></a>The playing field is a rectangular area and should be essentially flat, free of obstructions and afford reasonable player safety. Well trimmed grass is the recommended surface and all <span class="tooltip" title="A boundary defining the playing areas. On an unlined field, the boundary is an imaginary line segment between two field markers with the thickness of said markers. Line segments are not extrapolated beyond the defining markers.">line</span>s should be marked.</li>
-                <li><a id="4.B"></a>The standard field of play has dimensions as shown on the accompanying diagram (see <a href="https://usaultimate.org/rules/#appendix_a">Appendix A</a>).</li>
-                <li><a id="4.C"></a>The playing field is bounded by four perimeter <span class="tooltip" title="A boundary defining the playing areas. On an unlined field, the boundary is an imaginary line segment between two field markers with the thickness of said markers. Line segments are not extrapolated beyond the defining markers.">line</span>s: two (2) sidelines along the length and two (2) backlines along the width. The perimeter lines are not part of the playing field.</li>
-                <li><a id="4.D"></a>The playing field also includes two (2) goal lines parallel to the backlines. The two (2) areas bounded by each backline, the sidelines, and the nearest goal line are the end zones.</li>
+            <a id="4">4.</a> Playing Field
+            <ul>
+                <li><a id="4.A">4.A.</a> The playing field is a rectangular area and should be essentially flat, free of obstructions and afford reasonable player safety. Well trimmed grass is the recommended surface and all <span class="tooltip" title="A boundary defining the playing areas. On an unlined field, the boundary is an imaginary line segment between two field markers with the thickness of said markers. Line segments are not extrapolated beyond the defining markers.">line</span>s should be marked.</li>
+                <li><a id="4.B">4.B.</a> The standard field of play has dimensions as shown on the accompanying diagram (see <a href="https://usaultimate.org/rules/#appendix_a">Appendix A</a>).</li>
+                <li><a id="4.C">4.C.</a> The playing field is bounded by four perimeter <span class="tooltip" title="A boundary defining the playing areas. On an unlined field, the boundary is an imaginary line segment between two field markers with the thickness of said markers. Line segments are not extrapolated beyond the defining markers.">line</span>s: two (2) sidelines along the length and two (2) backlines along the width. The perimeter lines are not part of the playing field.</li>
+                <li><a id="4.D">4.D.</a> The playing field also includes two (2) goal lines parallel to the backlines. The two (2) areas bounded by each backline, the sidelines, and the nearest goal line are the end zones.</li>
                 <li>
-                    <a id="4.E"></a>The central zone is the playing field excluding the end zones.
+                    <a id="4.E">4.E.</a> The central zone is the playing field excluding the end zones.
                     <span class="annotation">[[Central zone was previously referred to as the playing field proper in previous editions of the rules.]]</span>
                 </li>
-                <li><a id="4.F"></a>The goal lines separate the central zone from the end zones and are part of the central zone.</li>
-                <li><a id="4.G"></a>Brick marks are located in the central zone a set distance from each goal line and midway between the sidelines. Reverse brick marks are located in each end zone midway between the goal line and backline and midway between the sidelines. A midfield mark is located midway between the goal lines and midway between the sidelines.</li>
-                <li><a id="4.H"></a>The corners of the central zone and the end zones are marked by brightly colored, flexible cones or pylons.</li>
+                <li><a id="4.F">4.F.</a> The goal lines separate the central zone from the end zones and are part of the central zone.</li>
+                <li><a id="4.G">4.G.</a> Brick marks are located in the central zone a set distance from each goal line and midway between the sidelines. Reverse brick marks are located in each end zone midway between the goal line and backline and midway between the sidelines. A midfield mark is located midway between the goal lines and midway between the sidelines.</li>
+                <li><a id="4.H">4.H.</a> The corners of the central zone and the end zones are marked by brightly colored, flexible cones or pylons.</li>
                 <li>
-                    <a id="4.I"></a>It is recommended that the following additional <span class="tooltip" title="A boundary defining the playing areas. On an unlined field, the boundary is an imaginary line segment between two field markers with the thickness of said markers. Line segments are not extrapolated beyond the defining markers.">line</span>s are also established.
-                    <ol>
-                        <li><a id="4.I.1"></a>The equipment line surrounds the playing field. Spectators and gear should remain behind this line to keep the perimeter safe and clear during play.</li>
+                    <a id="4.I">4.I.</a> It is recommended that the following additional <span class="tooltip" title="A boundary defining the playing areas. On an unlined field, the boundary is an imaginary line segment between two field markers with the thickness of said markers. Line segments are not extrapolated beyond the defining markers.">line</span>s are also established.
+                    <ul>
+                        <li><a id="4.I.1">4.I.1.</a> The equipment line surrounds the playing field. Spectators and gear should remain behind this line to keep the perimeter safe and clear during play.</li>
                         <li>
-                            <a id="4.I.2"></a>The team lines are outside of the playing field, parallel to the sidelines. Competitors and
+                            <a id="4.I.2">4.I.2.</a> The team lines are outside of the playing field, parallel to the sidelines. Competitors and
                             <span class="tooltip" title="A team member who has been officially recognized by event organizers to have met the requirements necessary for coaching, including but not limited to certification, screening, education, and registration. Coaches are permitted in areas where sideline players are allowed, during and between points, in accordance with event rules. Coaches are not permitted to make calls or contribute to the discussion or resolution of calls, except to clarify rules if requested.">coaches</span>
                             should remain behind these lines to allow play adjacent to the playing field.
                         </li>
-                    </ol>
+                    </ul>
                 </li>
 
                 <li>
-                    <a id="4.J"></a>If play is obstructed by competitors, <span class="tooltip" title="A team member who has been officially recognized by event organizers to have met the requirements necessary for coaching, including but not limited to certification, screening, education, and registration. Coaches are permitted in areas where sideline players are allowed, during and between points, in accordance with event rules. Coaches are not permitted to make calls or contribute to the discussion or resolution of calls, except to clarify rules if requested.">coaches</span>, spectators, or objects within five yards of the playing field, any obstructed player or the thrower in
+                    <a id="4.J">4.J.</a> If play is obstructed by competitors, <span class="tooltip" title="A team member who has been officially recognized by event organizers to have met the requirements necessary for coaching, including but not limited to certification, screening, education, and registration. Coaches are permitted in areas where sideline players are allowed, during and between points, in accordance with event rules. Coaches are not permitted to make calls or contribute to the discussion or resolution of calls, except to clarify rules if requested.">coaches</span>, spectators, or objects within five yards of the playing field, any obstructed player or the thrower in
                     <span class="tooltip" title="Sustained contact with, and control of, a non-spinning disc.">possession</span>
                     of the disc may call this violation. Play resumes at the stall count reached plus one, or 9 if over 8.
                 </li>
-            </ol>
+            </ul>
         </li>
 
         <li>
-            <a id="5"></a>Equipment
-            <ol>
+            <a id="5">5.</a> Equipment
+            <ul>
                 <li>
-                    <a id="5.A"></a>Any disc acceptable to both team
+                    <a id="5.A">5.A.</a> Any disc acceptable to both team
                     <span class="tooltip" title="A team member, who is eligible to participate in the game, and has been designated to represent the team in decision-making on behalf of the team before, during, and after a game.">captains</span>
                     may be used. If they cannot agree, the current Official Disc of USA Ultimate is used.
                 </li>
-                <li><a id="5.B"></a>Players may wear any soft clothing that does not endanger the safety of other players or provide unfair advantage.</li>
-                <li><a id="5.C"></a>Cleats with dangerous parts, such as metallic baseball cleats, track spikes, or worn or broken studs with sharp edges, are not allowed.</li>
-                <li><a id="5.D"></a>Each player must wear a uniform or other clothing distinguishing that player from players on the other team. In tournament play, matching uniforms and numbered jerseys are recommended.</li>
-                <li><a id="5.E"></a>Players may not use clothing or equipment to unfairly inhibit or assist the movement of the disc or another player.</li>
-                <li><a id="5.F"></a>Team members may not misuse game equipment in a manner that is likely to cause damage. <span class="annotation">[[Such actions include, but are not limited to, violently kicking field markers and deliberately spiking a disc in a way that is likely to alter the disc's flight characteristics.]]</span></li>
+                <li><a id="5.B">5.B.</a> Players may wear any soft clothing that does not endanger the safety of other players or provide unfair advantage.</li>
+                <li><a id="5.C">5.C.</a> Cleats with dangerous parts, such as metallic baseball cleats, track spikes, or worn or broken studs with sharp edges, are not allowed.</li>
+                <li><a id="5.D">5.D.</a> Each player must wear a uniform or other clothing distinguishing that player from players on the other team. In tournament play, matching uniforms and numbered jerseys are recommended.</li>
+                <li><a id="5.E">5.E.</a> Players may not use clothing or equipment to unfairly inhibit or assist the movement of the disc or another player.</li>
+                <li><a id="5.F">5.F.</a> Team members may not misuse game equipment in a manner that is likely to cause damage. <span class="annotation">[[Such actions include, but are not limited to, violently kicking field markers and deliberately spiking a disc in a way that is likely to alter the disc's flight characteristics.]]</span></li>
                 <li>
-                    <a id="5.G"></a>Team members may not use any form of acoustic amplifiers and/or electronic communication devices to communicate with players. Medically necessary devices are exempt from this rule.
+                    <a id="5.G">5.G.</a> Team members may not use any form of acoustic amplifiers and/or electronic communication devices to communicate with players. Medically necessary devices are exempt from this rule.
                     <span class="annotation"
                         >[[Team members not participating in the current point may communicate electronically with each other (e.g. <span class="tooltip" title="A team member who has been officially recognized by event organizers to have met the requirements necessary for coaching, including but not limited to certification, screening, education, and registration. Coaches are permitted in areas where sideline players are allowed, during and between points, in accordance with event rules. Coaches are not permitted to make calls or contribute to the discussion or resolution of calls, except to clarify rules if requested.">coaches</span>, <span class="tooltip" title="Any team member who is present at the field and eligible to participate in the game, but who is not a player participating in the current point.">sideline players</span>,
                         <span class="tooltip" title="A team member who has been officially recognized by event organizers to be a member of the team for a specific support purpose. Team support staff are generally permitted in areas where sideline players are allowed, but may be further restricted by event rules.">team support staff</span>, but not <span class="tooltip" title="One of the up to fourteen (14) persons who are participating in the current point of play.">players</span>).]]</span
                     >
                 </li>
-            </ol>
+            </ul>
         </li>
 
         <li>
-            <a id="6"></a>Length of Game
-            <ol>
+            <a id="6">6.</a> Length of Game
+            <ul>
                 <li>
-                    <a id="6.A"></a>The game total is the predetermined number of goals to win the game. A game is played until one team first reaches the game total.
-                    <ol>
-                        <li><a id="6.A.1"></a>A standard game has a game total of 15.</li>
-                    </ol>
+                    <a id="6.A">6.A.</a> The game total is the predetermined number of goals to win the game. A game is played until one team first reaches the game total.
+                    <ul>
+                        <li><a id="6.A.1">6.A.1.</a> A standard game has a game total of 15.</li>
+                    </ul>
                 </li>
 
                 <li>
-                    <a id="6.B"></a>The halftime target is the minimum number of goals necessary to reach or exceed half of the game total. Halftime begins when one team's score first reaches the halftime target.
+                    <a id="6.B">6.B.</a> The halftime target is the minimum number of goals necessary to reach or exceed half of the game total. Halftime begins when one team's score first reaches the halftime target.
                     <span class="annotation">[[In a game with a game total of 15, the halftime target will be 8.]]</span>
-                    <ol>
+                    <ul>
                         <li>
-                            <a id="6.B.1"></a>A standard halftime is 7 minutes.
+                            <a id="6.B.1">6.B.1.</a> A standard halftime is 7 minutes.
                             <span class="annotation">[[At the end of halftime, the standard time between pulls (9.C) begins, i.e., from the end of halftime, the offense has 50 seconds to line up and 60 seconds to signal readiness, and the defense has 80 seconds to <span class="tooltip" title="The throw from one team to the other that starts play at the beginning of a half or after a goal. It is not a legal pass for scoring and has many special provisions (Section 9.B). The player on the pulling team who possesses the disc and signals readiness is the puller.">pull</span>.]]</span>
                         </li>
-                    </ol>
+                    </ul>
                 </li>
 
                 <li>
-                    <a id="6.C"></a>Time Caps
-                    <ol>
+                    <a id="6.C">6.C.</a> Time Caps
+                    <ul>
                         <li>
-                            <a id="6.C.1"></a>The soft cap occurs once a predetermined time of play has elapsed. At the soft cap, play continues until the current
+                            <a id="6.C.1">6.C.1.</a> The soft cap occurs once a predetermined time of play has elapsed. At the soft cap, play continues until the current
                             <span class="tooltip" title="A scoring attempt starts at the beginning of the game or when the previous goal is scored and ends when the next goal is scored.">scoring attempt</span>
                             is completed. If, after the current scoring attempt is completed, the game total has not yet been reached by one team, one is added to the higher score and the resulting number is the new game total.
-                            <ol>
-                                <li><a id="#6.C.1.a"></a>If the soft cap occurs during the halftime break, the new game total is one more than the higher score. <span class="annotation">[[Don't play a point and then add one.]]</span></li>
-                            </ol>
+                            <ul>
+                                <li><a id="#6.C.1.a">#6.C.1.a.</a> If the soft cap occurs during the halftime break, the new game total is one more than the higher score. <span class="annotation">[[Don't play a point and then add one.]]</span></li>
+                            </ul>
                         </li>
                         <li>
-                            <a id="6.C.2"></a>The hard cap is the ending of the game once a predetermined time of play has elapsed. At the hard cap, play continues until the current
+                            <a id="6.C.2">6.C.2.</a> The hard cap is the ending of the game once a predetermined time of play has elapsed. At the hard cap, play continues until the current
                             <span class="tooltip" title="A scoring attempt starts at the beginning of the game or when the previous goal is scored and ends when the next goal is scored.">scoring attempt</span>
                             is completed. If, after the current scoring attempt is completed, the score is tied, play continues until one additional goal is scored. Otherwise, the game ends. The team with the most goals at the end of the game is the winner.
-                            <ol>
-                                <li><a id="#6.C.2.a"></a>If the hard cap occurs during the halftime break, the game is over and the team with the higher score is the winner.</li>
-                            </ol>
+                            <ul>
+                                <li><a id="#6.C.2.a">#6.C.2.a.</a> If the hard cap occurs during the halftime break, the game is over and the team with the higher score is the winner.</li>
+                            </ul>
                         </li>
                         <li>
-                            <a id="6.C.3"></a>The halftime cap occurs once a predetermined time of play has elapsed. At the halftime cap, play continues until the current
+                            <a id="6.C.3">6.C.3.</a> The halftime cap occurs once a predetermined time of play has elapsed. At the halftime cap, play continues until the current
                             <span class="tooltip" title="A scoring attempt starts at the beginning of the game or when the previous goal is scored and ends when the next goal is scored.">scoring attempt</span>
                             is completed. If, after the current scoring attempt is completed, the halftime target has not yet been reached by one team, one is added to the higher score and the resulting number is the new halftime target.
                         </li>
-                    </ol>
+                    </ul>
                 </li>
-            </ol>
+            </ul>
         </li>
 
         <li>
-            <a id="7"></a>Timeouts
-            <ol>
-                <li><a id="7.A"></a>A timeout stops play and suspends time limit counts.</li>
+            <a id="7">7.</a> Timeouts
+            <ul>
+                <li><a id="7.A">7.A.</a> A timeout stops play and suspends time limit counts.</li>
                 <li>
-                    <a id="7.B"></a>Team Timeout: Each team has two team timeouts per half in a standard game.
-                    <ol>
-                        <li><a id="7.B.1"></a>A team timeout lasts 70 seconds.</li>
-                        <li><a id="7.B.2"></a>Any player may call a timeout after a goal is scored and before both teams have signaled readiness to start play. Time limit counts between points are suspended for 70 seconds. A timeout may not be called between a re-pull call and the ensuing <span class="tooltip" title="The throw from one team to the other that starts play at the beginning of a half or after a goal. It is not a legal pass for scoring and has many special provisions (Section 9.B). The player on the pulling team who possesses the disc and signals readiness is the puller.">pull</span>.</li>
+                    <a id="7.B">7.B.</a> Team Timeout: Each team has two team timeouts per half in a standard game.
+                    <ul>
+                        <li><a id="7.B.1">7.B.1.</a> A team timeout lasts 70 seconds.</li>
+                        <li><a id="7.B.2">7.B.2.</a> Any player may call a timeout after a goal is scored and before both teams have signaled readiness to start play. Time limit counts between points are suspended for 70 seconds. A timeout may not be called between a re-pull call and the ensuing <span class="tooltip" title="The throw from one team to the other that starts play at the beginning of a half or after a goal. It is not a legal pass for scoring and has many special provisions (Section 9.B). The player on the pulling team who possesses the disc and signals readiness is the puller.">pull</span>.</li>
                         <li>
-                            <a id="7.B.3"></a>After the <span class="tooltip" title="The throw from one team to the other that starts play at the beginning of a half or after a goal. It is not a legal pass for scoring and has many special provisions (Section 9.B). The player on the pulling team who possesses the disc and signals readiness is the puller.">pull</span>, only a thrower with
+                            <a id="7.B.3">7.B.3.</a> After the <span class="tooltip" title="The throw from one team to the other that starts play at the beginning of a half or after a goal. It is not a legal pass for scoring and has many special provisions (Section 9.B). The player on the pulling team who possesses the disc and signals readiness is the puller.">pull</span>, only a thrower with
                             <span class="tooltip" title="Sustained contact with, and control of, a non-spinning disc.">possession</span>
                             of the disc that has survived
                             <span class="tooltip" title="All player contact with the ground directly related to a specific event or maneuver (e.g., jumping, diving, leaning or falling), including landing or recovering after being off-balance. Items on the ground are considered part of the ground.">ground contact</span>
                             can call a timeout. The player must form a T with one hand and the disc, and should audibly say “timeout.” The timeout begins when the T is formed. The disc is then placed on the ground at the pivot spot.
                         </li>
                         <li>
-                            <a id="7.B.4"></a>Restarting play after a timeout called by a thrower:
-                            <ol>
-                                <li><a id="7.B.4.a"></a>All players at the time of the timeout call must return to play unless an injury timeout also is called.</li>
+                            <a id="7.B.4">7.B.4.</a> Restarting play after a timeout called by a thrower:
+                            <ul>
+                                <li><a id="7.B.4.a">7.B.4.a.</a> All players at the time of the timeout call must return to play unless an injury timeout also is called.</li>
                                 <li>
-                                    <a id="7.B.4.b"></a>Each
+                                    <a id="7.B.4.b">7.B.4.b.</a> Each
                                     <span class="tooltip" title="A player whose team is in possession of the disc.">offensive player</span>
                                     must establish a stationary position by the end of the timeout. Movement after this time and before the disc is checked into play is a violation. The defense has ninety seconds after the beginning of the timeout or up to twenty seconds after all offensive players have established their positions (whichever is longer) to check the disc into play.
                                 </li>
                                 <li>
-                                    <a id="7.B.4.c"></a>The player who had
+                                    <a id="7.B.4.c">7.B.4.c.</a> The player who had
                                     <span class="tooltip" title="Sustained contact with, and control of, a non-spinning disc.">possession</span>
                                     of the disc when the team timeout was called restarts play with a check at the pivot spot, and the
                                     <span class="tooltip" title="The defensive player within ten feet of the thrower&#39;s pivot or of the thrower if no pivot has been established. If the disc is not in a player&#39;s possession, a defensive player within ten feet of a spot on the field where the disc is to be put into play is considered the marker.">marker</span>
                                     resumes the stall count with the word “stalling” followed by the last number uttered before the timeout plus one or 9 if over 8, however
                                     <a href="https://usaultimate.org/rules/#15.A.4">15.A.4</a> applies.
                                 </li>
-                                <li><a id="7.B.4.d"></a>If the time limits for the timeout are exceeded by one team, a player on the other team may announce “delay of game” and the player at the location the disc is to be put into play may self-check the disc into play without acknowledgment by the opposing team. In order to invoke this rule a player must give warnings of 20, 10, and 5 seconds.</li>
-                            </ol>
+                                <li><a id="7.B.4.d">7.B.4.d.</a> If the time limits for the timeout are exceeded by one team, a player on the other team may announce “delay of game” and the player at the location the disc is to be put into play may self-check the disc into play without acknowledgment by the opposing team. In order to invoke this rule a player must give warnings of 20, 10, and 5 seconds.</li>
+                            </ul>
                         </li>
 
                         <li>
-                            <a id="7.B.5"></a>If the disc is live or
+                            <a id="7.B.5">7.B.5.</a> If the disc is live or
                             <span class="tooltip" title="A disc is in play when players are allowed to move and play may proceed without the defense&#39;s acknowledgment. An in-bounds disc in the central zone is in play. The disc is subject to a turnover. If no player has possession of a disc in play, any offensive player may become the thrower by taking possession of the disc (14.A). Once a player has possession of the disc, they must establish a pivot at the spot of the disc 14.A.2) prior to attempting a pass (17.K).">in play</span>
                             and the thrower attempts to call a timeout when the team in possession has no timeouts remaining, play is stopped. The
                             <span class="tooltip" title="The defensive player within ten feet of the thrower&#39;s pivot or of the thrower if no pivot has been established. If the disc is not in a player&#39;s possession, a defensive player within ten feet of a spot on the field where the disc is to be put into play is considered the marker.">marker</span>
                             resumes the stall count with the number last uttered before the call plus three (e.g., if the timeout was called after a stall count of two, play would resume on a stall count of five). If this results in a stall count of ten or above, this is a turnover.
                         </li>
-                    </ol>
+                    </ul>
                 </li>
 
                 <li>
-                    <a id="7.C"></a>Injury Timeout: A timeout called for a player injury. During an injury timeout, the health and safety of the injured player are of primary concern.
-                    <ol>
-                        <li><a id="7.C.1"></a>Any player on the injured player's team may call an injury timeout.</li>
+                    <a id="7.C">7.C.</a> Injury Timeout: A timeout called for a player injury. During an injury timeout, the health and safety of the injured player are of primary concern.
+                    <ul>
+                        <li><a id="7.C.1">7.C.1.</a> Any player on the injured player's team may call an injury timeout.</li>
                         <li>
-                            <a id="7.C.2"></a>The timeout is retroactive to the time of the injury, unless the injured player chooses to continue play before the timeout is called, in which case, the timeout begins at the time of the call. If the disc is in the air or the thrower is in the act of throwing at the time of the injury or of the call when the player has continued play, the timeout begins when the play is completed.
-                            <ol>
-                                <li><a id="#7.C.2.a"></a>The health and safety of the injured player are of primary concern. If a serious injury occurs, other players change their behavior as a result of that injury, and the captains of both teams agree, the play may be resolved or play may be restarted in any appropriate manner despite any outcome dictated by these rules. <span class="annotation">[[This could include, for example, returning a thrown disc to the thrower regardless of the outcome, restarting the point with a re-pull, or delaying the restart of play.]]</span></li>
-                            </ol>
+                            <a id="7.C.2">7.C.2.</a> The timeout is retroactive to the time of the injury, unless the injured player chooses to continue play before the timeout is called, in which case, the timeout begins at the time of the call. If the disc is in the air or the thrower is in the act of throwing at the time of the injury or of the call when the player has continued play, the timeout begins when the play is completed.
+                            <ul>
+                                <li><a id="#7.C.2.a">#7.C.2.a.</a> The health and safety of the injured player are of primary concern. If a serious injury occurs, other players change their behavior as a result of that injury, and the captains of both teams agree, the play may be resolved or play may be restarted in any appropriate manner despite any outcome dictated by these rules. <span class="annotation">[[This could include, for example, returning a thrown disc to the thrower regardless of the outcome, restarting the point with a re-pull, or delaying the restart of play.]]</span></li>
+                            </ul>
                         </li>
                         <li>
-                            <a id="7.C.3"></a>Restarting play after an injury timeout:
-                            <ol>
+                            <a id="7.C.3">7.C.3.</a> Restarting play after an injury timeout:
+                            <ul>
                                 <li>
-                                    <a id="7.C.3.a"></a>If a player in
+                                    <a id="7.C.3.a">7.C.3.a.</a> If a player in
                                     <span class="tooltip" title="Sustained contact with, and control of, a non-spinning disc.">possession</span>
                                     leaves the field following an injury, the replacing player takes
                                     <span class="tooltip" title="Sustained contact with, and control of, a non-spinning disc.">possession</span>.
                                 </li>
                                 <li>
-                                    <a id="7.C.3.b"></a>Play restarts at the appropriate spot with a check and the
+                                    <a id="7.C.3.b">7.C.3.b.</a> Play restarts at the appropriate spot with a check and the
                                     <span class="tooltip" title="The defensive player within ten feet of the thrower&#39;s pivot or of the thrower if no pivot has been established. If the disc is not in a player&#39;s possession, a defensive player within ten feet of a spot on the field where the disc is to be put into play is considered the marker.">marker</span>
                                     resumes any stall count with the word stalling followed by the last number uttered before the injury timeout started plus one or 9 if over 8. The substitution of the thrower or
                                     <span class="tooltip" title="The defensive player within ten feet of the thrower&#39;s pivot or of the thrower if no pivot has been established. If the disc is not in a player&#39;s possession, a defensive player within ten feet of a spot on the field where the disc is to be put into play is considered the marker.">marker</span>
                                     does not alter the stall count.
                                 </li>
-                                <li><a id="7.C.3.c"></a>All players must resume their locations on the field at the time the injury timeout began (i.e., players may not set up), unless a team timeout is also called.</li>
-                            </ol>
+                                <li><a id="7.C.3.c">7.C.3.c.</a> All players must resume their locations on the field at the time the injury timeout began (i.e., players may not set up), unless a team timeout is also called.</li>
+                            </ul>
                         </li>
 
-                        <li><a id="7.C.4"></a>If the injured player does not leave the game after an injury timeout, that player's team is charged with a team timeout unless the injury was caused by an opposing player. If the team being charged with the timeout is also the team in possession and has no timeouts remaining, it is a turnover.</li>
-                        <li><a id="7.C.5"></a>If an injury timeout is called during a team timeout, the opposing team must be notified as soon as the injury is discovered (<a href="https://usaultimate.org/rules/#8.A.2">8.A.2</a>).</li>
-                        <li><a id="7.C.6"></a>If an injury timeout is called between points, all time limits are suspended until the injured player is removed from the field.</li>
+                        <li><a id="7.C.4">7.C.4.</a> If the injured player does not leave the game after an injury timeout, that player's team is charged with a team timeout unless the injury was caused by an opposing player. If the team being charged with the timeout is also the team in possession and has no timeouts remaining, it is a turnover.</li>
+                        <li><a id="7.C.5">7.C.5.</a> If an injury timeout is called during a team timeout, the opposing team must be notified as soon as the injury is discovered (<a href="https://usaultimate.org/rules/#8.A.2">8.A.2</a>).</li>
+                        <li><a id="7.C.6">7.C.6.</a> If an injury timeout is called between points, all time limits are suspended until the injured player is removed from the field.</li>
                         <li>
-                            <a id="7.C.7"></a>Any <span class="tooltip" title="One of the up to fourteen (14) persons who are participating in the current point of play.">player,</span> <span class="tooltip" title="A team member who has been officially recognized by event organizers to have met the requirements necessary for coaching, including but not limited to certification, screening, education, and registration. Coaches are permitted in areas where sideline players are allowed, during and between points, in accordance with event rules. Coaches are not permitted to make calls or contribute to the discussion or resolution of calls, except to clarify rules if requested.">coach</span>, or
+                            <a id="7.C.7">7.C.7.</a> Any <span class="tooltip" title="One of the up to fourteen (14) persons who are participating in the current point of play.">player,</span> <span class="tooltip" title="A team member who has been officially recognized by event organizers to have met the requirements necessary for coaching, including but not limited to certification, screening, education, and registration. Coaches are permitted in areas where sideline players are allowed, during and between points, in accordance with event rules. Coaches are not permitted to make calls or contribute to the discussion or resolution of calls, except to clarify rules if requested.">coach</span>, or
                             <span class="tooltip" title="Observers are non-player game officials whose job is to support the players in implementing a safe, fair, and efficient game. Observers carefully watch the action of the game, assist with communication, help uphold self-officiating and the Spirit of the Game, assist with resolving calls as needed, and perform other duties as described in Section 19">observer</span>
                             should call an injury timeout for a player who is bleeding or has an exposed open wound.
-                            <ol>
-                                <li><a id="7.C.7.a"></a>This timeout takes effect when the call is made (i.e., is not retroactive to the time of injury). If the disc is in the air or the thrower is in the act of throwing at the time of the call, the timeout begins when the play is completed. However, the disc is returned to the thrower if avoiding potential contact with the bleeding player is determined to have affected the play.</li>
-                                <li><a id="7.C.7.b"></a>This timeout may last up to 70 seconds, during which time the injured player must have the wound effectively covered in order to return to the point in progress.</li>
+                            <ul>
+                                <li><a id="7.C.7.a">7.C.7.a.</a> This timeout takes effect when the call is made (i.e., is not retroactive to the time of injury). If the disc is in the air or the thrower is in the act of throwing at the time of the call, the timeout begins when the play is completed. However, the disc is returned to the thrower if avoiding potential contact with the bleeding player is determined to have affected the play.</li>
+                                <li><a id="7.C.7.b">7.C.7.b.</a> This timeout may last up to 70 seconds, during which time the injured player must have the wound effectively covered in order to return to the point in progress.</li>
                                 <li>
-                                    <a id="7.C.7.c"></a>If play cannot be restarted with the injured player's wound effectively covered in 70 seconds, the player's team may either
-                                    <ol>
-                                        <li><a id="7.C.7.c.1"></a>replace the injured player according to <a href="https://usaultimate.org/rules/#7.C.3">7.C.3</a>, or</li>
-                                        <li><a id="7.C.7.c.2"></a>call a team timeout, if they have one, in order to extend the time frame to have the wound effectively covered and leave the player in the game.</li>
-                                    </ol>
+                                    <a id="7.C.7.c">7.C.7.c.</a> If play cannot be restarted with the injured player's wound effectively covered in 70 seconds, the player's team may either
+                                    <ul>
+                                        <li><a id="7.C.7.c.1">7.C.7.c.1.</a> replace the injured player according to <a href="https://usaultimate.org/rules/#7.C.3">7.C.3</a>, or</li>
+                                        <li><a id="7.C.7.c.2">7.C.7.c.2.</a> call a team timeout, if they have one, in order to extend the time frame to have the wound effectively covered and leave the player in the game.</li>
+                                    </ul>
                                 </li>
 
-                                <li><a id="7.C.7.d"></a>A bleeding or exposed open wound is “effectively covered” if it is covered with a dressing sturdy enough to withstand the demands of activity and able to prevent bodily fluids from coming in contact with other players.</li>
-                                <li><a id="7.C.7.e"></a>Any player whose clothing has blood on it must have the affected areas disinfected or must change the clothing before returning to play.</li>
+                                <li><a id="7.C.7.d">7.C.7.d.</a> A bleeding or exposed open wound is “effectively covered” if it is covered with a dressing sturdy enough to withstand the demands of activity and able to prevent bodily fluids from coming in contact with other players.</li>
+                                <li><a id="7.C.7.e">7.C.7.e.</a> Any player whose clothing has blood on it must have the affected areas disinfected or must change the clothing before returning to play.</li>
                                 <li>
-                                    <a id="7.C.7.f"></a>Whether a player may return to play is determined by appropriate medical staff. If medical staff is not available,
+                                    <a id="7.C.7.f">7.C.7.f.</a> Whether a player may return to play is determined by appropriate medical staff. If medical staff is not available,
                                     <span class="tooltip" title="A team member, who is eligible to participate in the game, and has been designated to represent the team in decision-making on behalf of the team before, during, and after a game.">captains</span>
                                     and
                                     <span class="tooltip" title="A team member who has been officially recognized by event organizers to have met the requirements necessary for coaching, including but not limited to certification, screening, education, and registration. Coaches are permitted in areas where sideline players are allowed, during and between points, in accordance with event rules. Coaches are not permitted to make calls or contribute to the discussion or resolution of calls, except to clarify rules if requested.">coaches</span>
                                     may agree that a wound has been effectively covered and any clothing issues have been addressed.
                                 </li>
-                            </ol>
+                            </ul>
                         </li>
-                    </ol>
+                    </ul>
                 </li>
 
                 <li>
-                    <a id="7.D"></a>Technical Timeout: A technical timeout may be called for illegal equipment, a dangerous condition, or a broken disc.
-                    <ol>
+                    <a id="7.D">7.D.</a> Technical Timeout: A technical timeout may be called for illegal equipment, a dangerous condition, or a broken disc.
+                    <ul>
                         <li>
-                            <a id="7.D.1"></a>Any player recognizing a condition that endangers themselves or other players may call a technical timeout during play by calling “technical.” The thrower may call a technical timeout during play to replace a cracked, torn, deeply gouged, creased, or punctured disc; a warped, wet or dirty disc does not qualify. The timeout begins at the time of the call. If the disc is in the air or the act of throwing at the time of the call, the timeout begins when the play is completed.
-                            <ol>
+                            <a id="7.D.1">7.D.1.</a> Any player recognizing a condition that endangers themselves or other players may call a technical timeout during play by calling “technical.” The thrower may call a technical timeout during play to replace a cracked, torn, deeply gouged, creased, or punctured disc; a warped, wet or dirty disc does not qualify. The timeout begins at the time of the call. If the disc is in the air or the act of throwing at the time of the call, the timeout begins when the play is completed.
+                            <ul>
                                 <li>
-                                    <a id="7.D.1.a"></a>If a player discovers a dangerous condition after the disc is in the air or while the thrower is in the act of throwing and the player ceases play as a result, the disc is returned to the thrower regardless of the outcome of that pass. However, if both teams agree that ceasing play did not affect the outcome of the throw, the result of the play stands.
+                                    <a id="7.D.1.a">7.D.1.a.</a> If a player discovers a dangerous condition after the disc is in the air or while the thrower is in the act of throwing and the player ceases play as a result, the disc is returned to the thrower regardless of the outcome of that pass. However, if both teams agree that ceasing play did not affect the outcome of the throw, the result of the play stands.
                                     <span class="annotation">[[For example, a receiver is not required to continue playing through a dangerous situation, such as a child wandering onto the field. In that case, the receiver should stop making a play on the disc in order to prioritize the safety of themselves and others, and the disc will be returned to the thrower once the dangerous situation is rectified.]]</span>
-                                    <ol>
-                                        <li><a id="7.D.1.a.1"></a>If possession reverts to the thrower, all players return to the locations they occupied at the time of the throw</li>
-                                    </ol>
+                                    <ul>
+                                        <li><a id="7.D.1.a.1">7.D.1.a.1.</a> If possession reverts to the thrower, all players return to the locations they occupied at the time of the throw</li>
+                                    </ul>
                                 </li>
-                            </ol>
+                            </ul>
                         </li>
 
                         <li>
-                            <a id="7.D.2"></a>Any player may briefly extend a
+                            <a id="7.D.2">7.D.2.</a> Any player may briefly extend a
                             <span class="tooltip" title="Any halting of play due to a call, discussion, or timeout that requires a check or self-check to restart play. The term play stops means a stoppage of play occurs.">stoppage of play</span>
                             to correct faulty equipment (e.g., to tie shoelaces or straighten a disc), but active play may not be stopped for this purpose. (Note: play does not stop during a turnover even if the disc is out-of-bounds.)
                         </li>
-                        <li><a id="7.D.3"></a>A player unable to correct illegal equipment in a timely manner must be substituted in accordance with <a href="https://usaultimate.org/rules/#8.A.2">8.A.2</a>.</li>
+                        <li><a id="7.D.3">7.D.3.</a> A player unable to correct illegal equipment in a timely manner must be substituted in accordance with <a href="https://usaultimate.org/rules/#8.A.2">8.A.2</a>.</li>
                         <li>
-                            <a id="7.D.4"></a>Restarting play after a technical timeout:
-                            <ol>
+                            <a id="7.D.4">7.D.4.</a> Restarting play after a technical timeout:
+                            <ul>
                                 <li>
-                                    <a id="7.D.4.a"></a>The thrower restarts play at the appropriate spot with a check and the
+                                    <a id="7.D.4.a">7.D.4.a.</a> The thrower restarts play at the appropriate spot with a check and the
                                     <span class="tooltip" title="The defensive player within ten feet of the thrower&#39;s pivot or of the thrower if no pivot has been established. If the disc is not in a player&#39;s possession, a defensive player within ten feet of a spot on the field where the disc is to be put into play is considered the marker.">marker</span>
                                     resumes any stall count as follows:
-                                    <ol>
-                                        <li><a id="7.D.4.a.1"></a>If the technical timeout was called during a <span class="tooltip" title="Any halting of play due to a call, discussion, or timeout that requires a check or self-check to restart play. The term play stops means a stoppage of play occurs.">stoppage of play</span>, the count resumes at the appropriate count for the event that stopped play.</li>
-                                        <li><a id="7.D.4.a.2"></a>If the technical timeout stopped play, the count resumes at the stall count reached plus one, or at six if over five.</li>
-                                    </ol>
+                                    <ul>
+                                        <li><a id="7.D.4.a.1">7.D.4.a.1.</a> If the technical timeout was called during a <span class="tooltip" title="Any halting of play due to a call, discussion, or timeout that requires a check or self-check to restart play. The term play stops means a stoppage of play occurs.">stoppage of play</span>, the count resumes at the appropriate count for the event that stopped play.</li>
+                                        <li><a id="7.D.4.a.2">7.D.4.a.2.</a> If the technical timeout stopped play, the count resumes at the stall count reached plus one, or at six if over five.</li>
+                                    </ul>
                                 </li>
 
                                 <li>
-                                    <a id="7.D.4.b"></a>If a player in possession leaves the field due to illegal equipment, the replacing player puts the disc into play. The substitution of the thrower or
+                                    <a id="7.D.4.b">7.D.4.b.</a> If a player in possession leaves the field due to illegal equipment, the replacing player puts the disc into play. The substitution of the thrower or
                                     <span class="tooltip" title="The defensive player within ten feet of the thrower&#39;s pivot or of the thrower if no pivot has been established. If the disc is not in a player&#39;s possession, a defensive player within ten feet of a spot on the field where the disc is to be put into play is considered the marker.">marker</span>
                                     does not alter the stall count.
                                 </li>
-                                <li><a id="7.D.4.c"></a>All players must resume their locations on the field at the time the timeout began (i.e., players may not set up), unless a team timeout is also called.</li>
-                            </ol>
+                                <li><a id="7.D.4.c">7.D.4.c.</a> All players must resume their locations on the field at the time the timeout began (i.e., players may not set up), unless a team timeout is also called.</li>
+                            </ul>
                         </li>
-                    </ol>
+                    </ul>
                 </li>
 
                 <li>
-                    <a id="7.E"></a>Spirit timeout: A spirit timeout may be called by one or both teams'
+                    <a id="7.E">7.E.</a> Spirit timeout: A spirit timeout may be called by one or both teams'
                     <span class="tooltip" title="A team member, who is eligible to participate in the game, and has been designated to address, discuss, and resolve spirit issues at any point throughout the competition with their opponents, teammates, coaches, and game or event officials.">spirit captain(s)</span>
                     if they believe that either or both teams have failed to follow the Spirit of the Game, and (1) game play has become dangerous; or (2) repeated Spirit of the Game violations are causing conflict between the teams. Spirit timeouts are subject to the following provisions:
-                    <ol>
+                    <ul>
                         <li>
-                            <a id="7.E.1"></a>A spirit timeout can be called only if all of the following conditions have been met:
-                            <ol>
+                            <a id="7.E.1">7.E.1.</a> A spirit timeout can be called only if all of the following conditions have been met:
+                            <ul>
                                 <li>
-                                    <a id="7.E.1.a"></a>Both
+                                    <a id="7.E.1.a">7.E.1.a.</a> Both
                                     <span class="tooltip" title="A team member, who is eligible to participate in the game, and has been designated to address, discuss, and resolve spirit issues at any point throughout the competition with their opponents, teammates, coaches, and game or event officials.">spirit captains</span>
                                     have discussed the perceived Spirit of the Game violation(s) and adjustments to address those violations, and one or more members of either or both teams have not adjusted their conduct.
                                 </li>
                                 <li>
-                                    <a id="7.E.1.b"></a>Both
+                                    <a id="7.E.1.b">7.E.1.b.</a> Both
                                     <span class="tooltip" title="A team member, who is eligible to participate in the game, and has been designated to address, discuss, and resolve spirit issues at any point throughout the competition with their opponents, teammates, coaches, and game or event officials.">spirit captains</span>
                                     have discussed the need to call a spirit timeout before calling the spirit timeout. It is not required that both spirit captains agree that a spirit timeout is necessary.
                                 </li>
-                                <li><a id="7.E.1.c"></a>Play is stopped.</li>
-                                <li><a id="7.E.1.d"></a>In games with <span class="tooltip" title="Observers are non-player game officials whose job is to support the players in implementing a safe, fair, and efficient game. Observers carefully watch the action of the game, assist with communication, help uphold self-officiating and the Spirit of the Game, assist with resolving calls as needed, and perform other duties as described in Section 19">observers</span>, spirit timeouts initiated by the <span class="tooltip" title="A team member, who is eligible to participate in the game, and has been designated to address, discuss, and resolve spirit issues at any point throughout the competition with their opponents, teammates, coaches, and game or event officials.">spirit captains</span> must be communicated to the observers before being called. Observers may call a spirit timeout if the observer believes it is needed and at least one of the spirit captains agrees.</li>
-                            </ol>
+                                <li><a id="7.E.1.c">7.E.1.c.</a> Play is stopped.</li>
+                                <li><a id="7.E.1.d">7.E.1.d.</a> In games with <span class="tooltip" title="Observers are non-player game officials whose job is to support the players in implementing a safe, fair, and efficient game. Observers carefully watch the action of the game, assist with communication, help uphold self-officiating and the Spirit of the Game, assist with resolving calls as needed, and perform other duties as described in Section 19">observers</span>, spirit timeouts initiated by the <span class="tooltip" title="A team member, who is eligible to participate in the game, and has been designated to address, discuss, and resolve spirit issues at any point throughout the competition with their opponents, teammates, coaches, and game or event officials.">spirit captains</span> must be communicated to the observers before being called. Observers may call a spirit timeout if the observer believes it is needed and at least one of the spirit captains agrees.</li>
+                            </ul>
                         </li>
 
                         <li>
-                            <a id="7.E.2"></a>During the spirit timeout:
-                            <ol>
-                                <li><a id="7.E.2.a"></a>Both teams will aim to complete all discussions within 5 minutes, with a goal of resuming play as quickly as possible. If teams require more time to resolve spirit discussions, the timeout can be extended with the consent of both <span class="tooltip" title="A team member, who is eligible to participate in the game, and has been designated to address, discuss, and resolve spirit issues at any point throughout the competition with their opponents, teammates, coaches, and game or event officials.">spirit captains</span>.</li>
+                            <a id="7.E.2">7.E.2.</a> During the spirit timeout:
+                            <ul>
+                                <li><a id="7.E.2.a">7.E.2.a.</a> Both teams will aim to complete all discussions within 5 minutes, with a goal of resuming play as quickly as possible. If teams require more time to resolve spirit discussions, the timeout can be extended with the consent of both <span class="tooltip" title="A team member, who is eligible to participate in the game, and has been designated to address, discuss, and resolve spirit issues at any point throughout the competition with their opponents, teammates, coaches, and game or event officials.">spirit captains</span>.</li>
                                 <li>
-                                    <a id="7.E.2.b"></a><span class="tooltip" title="Any person designated by the team, to the event organizer, to be officially associated with the team, per the rules established by the event organizer.">Team members</span>
+                                    <a id="7.E.2.b">7.E.2.b.</a> <span class="tooltip" title="Any person designated by the team, to the event organizer, to be officially associated with the team, per the rules established by the event organizer.">Team members</span>
                                     may not engage in tactical discussions. Team members may not extend the spirit timeout to try to gain a tactical advantage.
                                 </li>
                                 <li>
-                                    <a id="7.E.2.c"></a>Spirit timeouts may follow one of two formats, as determined by the <span class="tooltip" title="A team member, who is eligible to participate in the game, and has been designated to address, discuss, and resolve spirit issues at any point throughout the competition with their opponents, teammates, coaches, and game or event officials.">spirit captains</span>. Where the spirit captains disagree as to the format of the spirit timeout, the default format is for teams to form one circle.
-                                    <ol>
+                                    <a id="7.E.2.c">7.E.2.c.</a> Spirit timeouts may follow one of two formats, as determined by the <span class="tooltip" title="A team member, who is eligible to participate in the game, and has been designated to address, discuss, and resolve spirit issues at any point throughout the competition with their opponents, teammates, coaches, and game or event officials.">spirit captains</span>. Where the spirit captains disagree as to the format of the spirit timeout, the default format is for teams to form one circle.
+                                    <ul>
                                         <li>
-                                            <a id="7.E.2.c.1"></a>All
+                                            <a id="7.E.2.c.1">7.E.2.c.1.</a> All
                                             <span class="tooltip" title="Any person designated by the team, to the event organizer, to be officially associated with the team, per the rules established by the event organizer.">team members</span>
                                             of both teams will form one circle, alternating players from each team, if possible. The
                                             <span class="tooltip" title="A team member, who is eligible to participate in the game, and has been designated to address, discuss, and resolve spirit issues at any point throughout the competition with their opponents, teammates, coaches, and game or event officials.">spirit captains</span>
                                             will lead a conversation addressing and proposing solutions to resolve spirit issues; or
                                         </li>
                                         <li>
-                                            <a id="7.E.2.c.2"></a>Two circles will be formed, one for each team to internally resolve spirit issues that have already been discussed between the
+                                            <a id="7.E.2.c.2">7.E.2.c.2.</a> Two circles will be formed, one for each team to internally resolve spirit issues that have already been discussed between the
                                             <span class="tooltip" title="A team member, who is eligible to participate in the game, and has been designated to address, discuss, and resolve spirit issues at any point throughout the competition with their opponents, teammates, coaches, and game or event officials.">spirit captains</span>
                                             of the opposing team.
                                         </li>
-                                    </ol>
+                                    </ul>
                                 </li>
-                            </ol>
+                            </ul>
                         </li>
 
                         <li>
-                            <a id="7.E.3"></a>After the spirit timeout:
-                            <ol>
-                                <li><a id="7.E.3.a"></a>The game resumes in the same manner as it does after a team timeout.</li>
-                                <li><a id="7.E.3.b"></a>Spirit timeouts do not affect timeouts available.</li>
+                            <a id="7.E.3">7.E.3.</a> After the spirit timeout:
+                            <ul>
+                                <li><a id="7.E.3.a">7.E.3.a.</a> The game resumes in the same manner as it does after a team timeout.</li>
+                                <li><a id="7.E.3.b">7.E.3.b.</a> Spirit timeouts do not affect timeouts available.</li>
                                 <li>
-                                    <a id="7.E.3.c"></a>For spirit timeouts lasting five minutes or less, the time taken for a spirit timeout will automatically be added to the length of the game time to determine time caps for the game. After the initial five minutes, although
+                                    <a id="7.E.3.c">7.E.3.c.</a> For spirit timeouts lasting five minutes or less, the time taken for a spirit timeout will automatically be added to the length of the game time to determine time caps for the game. After the initial five minutes, although
                                     <span class="tooltip" title="A team member, who is eligible to participate in the game, and has been designated to address, discuss, and resolve spirit issues at any point throughout the competition with their opponents, teammates, coaches, and game or event officials.">spirit captains</span>
                                     may always agree to extend a spirit timeout, event organizers may limit the time that can be added to the length of games. The spirit captain(s) initiating the spirit timeout will convey the start and end of the stoppage to
                                     <span class="tooltip" title="Event support staff are officially designated personnel assigned by the event organizers to cover a wide variety of positions and responsibilities associated with an event, including but not limited to medical staff, scorekeepers, security, media, field crew, and other paid or volunteer positions. Vendors, sponsors, and business partners may also be designated as event support staff by the event organizer. Event support staff do not have additional duties or permissions beyond those specifically assigned by the event organizer.">event support staff</span>
                                     or the <span class="tooltip" title="The person(s) or entity organizing and responsible for a competition, whether it is a tournament, tournament series, league, single game, or other type of event. Responsibilities may include, but are not limited to competition rules, safety, event registration and event logistics.">event organizer</span> for time-keeping purposes.
                                 </li>
-                            </ol>
+                            </ul>
                         </li>
-                    </ol>
+                    </ul>
                 </li>
 
-                <li><a id="7.F"></a>Injury, technical, and spirit timeouts are meant to be used exclusively to address the issue for which the timeout was called. Only personnel needed to address the issue should be on the field and only for that purpose. Teams may not use these timeouts as team timeouts, unless they also call a team timeout.</li>
-            </ol>
+                <li><a id="7.F">7.F.</a> Injury, technical, and spirit timeouts are meant to be used exclusively to address the issue for which the timeout was called. Only personnel needed to address the issue should be on the field and only for that purpose. Teams may not use these timeouts as team timeouts, unless they also call a team timeout.</li>
+            </ul>
         </li>
 
         <li>
-            <a id="8"></a>Player Substitutions
-            <ol>
+            <a id="8">8.</a> Player Substitutions
+            <ul>
                 <li>
-                    <a id="8.A"></a>Player substitutions can be completed only:
-                    <ol>
-                        <li><a id="8.A.1"></a>after a goal and before the substituting team has signaled readiness; or</li>
-                        <li><a id="8.A.2"></a>to replace injured players, replace players with illegal equipment (<a href="https://usaultimate.org/rules/#7.D.3">7.D.3</a>), to resolve an incorrect personnel violation (<a href="https://usaultimate.org/rules/#9.B.3.a">9.8.3.a</a>), or to replace a player removed due to misconduct (<a href="https://usaultimate.org/rules/#2.C.2">2.C.2</a>, <a href="https://usaultimate.org/rules/#appendix_b">Appendix B</a>). In this case, the opposing team may substitute a like number of, or fewer, players.</li>
-                    </ol>
+                    <a id="8.A">8.A.</a> Player substitutions can be completed only:
+                    <ul>
+                        <li><a id="8.A.1">8.A.1.</a> after a goal and before the substituting team has signaled readiness; or</li>
+                        <li><a id="8.A.2">8.A.2.</a> to replace injured players, replace players with illegal equipment (<a href="https://usaultimate.org/rules/#7.D.3">7.D.3</a>), to resolve an incorrect personnel violation (<a href="https://usaultimate.org/rules/#9.B.3.a">9.8.3.a</a>), or to replace a player removed due to misconduct (<a href="https://usaultimate.org/rules/#2.C.2">2.C.2</a>, <a href="https://usaultimate.org/rules/#appendix_b">Appendix B</a>). In this case, the opposing team may substitute a like number of, or fewer, players.</li>
+                    </ul>
                 </li>
 
-                <li><a id="8.B"></a>Substitutions are not permitted following a re-pull call, unless in accordance with <a href="https://usaultimate.org/rules/#8.A.2">8.A.2</a>.</li>
-            </ol>
+                <li><a id="8.B">8.B.</a> Substitutions are not permitted following a re-pull call, unless in accordance with <a href="https://usaultimate.org/rules/#8.A.2">8.A.2</a>.</li>
+            </ul>
         </li>
 
         <li>
-            <a id="9"></a>Starting and Restarting Play
-            <ol>
+            <a id="9">9.</a> Starting and Restarting Play
+            <ul>
                 <li>
-                    <a id="9.A"></a>Start of the game:
-                    <ol>
+                    <a id="9.A">9.A.</a> Start of the game:
+                    <ul>
                         <li>
-                            <a id="9.A.1"></a>Representatives of the two teams fairly determine which team chooses to
-                            <ol>
-                                <li><a id="9.A.1.a"></a>receive or throw the initial <span class="tooltip" title="The throw from one team to the other that starts play at the beginning of a half or after a goal. It is not a legal pass for scoring and has many special provisions (Section 9.B). The player on the pulling team who possesses the disc and signals readiness is the puller.">pull</span>; or</li>
-                                <li><a id="9.A.1.b"></a>which end zone they wish to initially defend.</li>
-                            </ol>
+                            <a id="9.A.1">9.A.1.</a> Representatives of the two teams fairly determine which team chooses to
+                            <ul>
+                                <li><a id="9.A.1.a">9.A.1.a.</a> receive or throw the initial <span class="tooltip" title="The throw from one team to the other that starts play at the beginning of a half or after a goal. It is not a legal pass for scoring and has many special provisions (Section 9.B). The player on the pulling team who possesses the disc and signals readiness is the puller.">pull</span>; or</li>
+                                <li><a id="9.A.1.b">9.A.1.b.</a> which end zone they wish to initially defend.</li>
+                            </ul>
                         </li>
 
-                        <li><a id="9.A.2"></a>The other team gets the remaining choice.</li>
-                        <li><a id="9.A.3"></a>The second half begins with a reversal of the initial choices.</li>
-                        <li><a id="9.A.4"></a>If only one team fails to signal readiness for the start of a scheduled game, the opposing team may be awarded goals by the event organizer at a rate of one goal for every five minutes elapsed after the posted start time.</li>
-                    </ol>
+                        <li><a id="9.A.2">9.A.2.</a> The other team gets the remaining choice.</li>
+                        <li><a id="9.A.3">9.A.3.</a> The second half begins with a reversal of the initial choices.</li>
+                        <li><a id="9.A.4">9.A.4.</a> If only one team fails to signal readiness for the start of a scheduled game, the opposing team may be awarded goals by the event organizer at a rate of one goal for every five minutes elapsed after the posted start time.</li>
+                    </ul>
                 </li>
 
                 <li>
-                    <a id="9.B"></a>Pull:
-                    <ol>
-                        <li><a id="9.B.1"></a>Play starts at the beginning of each half and after each goal with a <span class="tooltip" title="The throw from one team to the other that starts play at the beginning of a half or after a goal. It is not a legal pass for scoring and has many special provisions (Section 9.B). The player on the pulling team who possesses the disc and signals readiness is the puller.">pull</span>.</li>
-                        <li><a id="9.B.2"></a>After a goal, the teams switch their direction of attack and the scoring team pulls.</li>
+                    <a id="9.B">9.B.</a> Pull:
+                    <ul>
+                        <li><a id="9.B.1">9.B.1.</a> Play starts at the beginning of each half and after each goal with a <span class="tooltip" title="The throw from one team to the other that starts play at the beginning of a half or after a goal. It is not a legal pass for scoring and has many special provisions (Section 9.B). The player on the pulling team who possesses the disc and signals readiness is the puller.">pull</span>.</li>
+                        <li><a id="9.B.2">9.B.2.</a> After a goal, the teams switch their direction of attack and the scoring team pulls.</li>
                         <li>
-                            <a id="9.B.3"></a>The
+                            <a id="9.B.3">9.B.3.</a> The
                             <span class="tooltip" title="The throw from one team to the other that starts play at the beginning of a half or after a goal. It is not a legal pass for scoring and has many special provisions (Section 9.B). The player on the pulling team who possesses the disc and signals readiness is the puller.">pull</span>
                             may be made only after the puller and a player on the receiving team both raise their hands to signal their team's readiness to begin play. A team must have a minimum of two players and a maximum of seven players on the field in order to signal readiness. The pull occurs when the puller throws (<a href="https://usaultimate.org/rules/#3.K">3.K</a>) the disc after signaling readiness.
                             <span class="annotation">[[Players (<a href="https://usaultimate.org/rules/#3.Q.10">3.Q.10</a>) may not signal readiness until all of their other team members are clear of the field (<a href="https://usaultimate.org/rules/#9.C.4.a">9.C.4.a</a>).]]</span>
-                            <ol>
+                            <ul>
                                 <li>
-                                    <a id="9.B.3.a"></a>If the disc has been pulled and a team has more than seven (7) players or has the incorrect mixed personnel ratio, it is the responsibility of all players on the field to call violation as soon as they recognize it.
+                                    <a id="9.B.3.a">9.B.3.a.</a> If the disc has been pulled and a team has more than seven (7) players or has the incorrect mixed personnel ratio, it is the responsibility of all players on the field to call violation as soon as they recognize it.
                                     <span class="annotation">[[This rule is one of the exceptions to <a href="https://usaultimate.org/rules/#17.A">17.A</a>, and this violation call is always appropriate under <a href="https://usaultimate.org/rules/#2.D.2">2.D.2</a>.]]</span>
-                                    <ol>
-                                        <li><a id="9.B.3.a.1"></a>The team in violation must choose which player(s) to remove from their team, in the case of too many players, or substitute, in the case of an incorrect mixed personnel ratio.</li>
-                                        <li><a id="9.B.3.a.2"></a>For every player removed or substituted by the team in violation, the other team may substitute a player.</li>
-                                        <li><a id="9.B.3.a.3"></a>After correcting the violation, the other team chooses whether to restart the point using re-pull timings (<a href="https://usaultimate.org/rules/#9.C.6.a">9.C.6.a</a>) or to restart play as if a team timeout had been called (<a href="https://usaultimate.org/rules/#7.B.4">7.B.4</a>) with the stall count determined by the applicable violation resolution of <a href="https://usaultimate.org/rules/#15.A.5.a">15.A.5.a</a>. If both teams are in violation, the point should be restarted unless both teams agree to restart play as if a team timeout had been called.</li>
+                                    <ul>
+                                        <li><a id="9.B.3.a.1">9.B.3.a.1.</a> The team in violation must choose which player(s) to remove from their team, in the case of too many players, or substitute, in the case of an incorrect mixed personnel ratio.</li>
+                                        <li><a id="9.B.3.a.2">9.B.3.a.2.</a> For every player removed or substituted by the team in violation, the other team may substitute a player.</li>
+                                        <li><a id="9.B.3.a.3">9.B.3.a.3.</a> After correcting the violation, the other team chooses whether to restart the point using re-pull timings (<a href="https://usaultimate.org/rules/#9.C.6.a">9.C.6.a</a>) or to restart play as if a team timeout had been called (<a href="https://usaultimate.org/rules/#7.B.4">7.B.4</a>) with the stall count determined by the applicable violation resolution of <a href="https://usaultimate.org/rules/#15.A.5.a">15.A.5.a</a>. If both teams are in violation, the point should be restarted unless both teams agree to restart play as if a team timeout had been called.</li>
                                         <li>
-                                            <a id="9.B.3.a.4"></a>If a violation of <a href="https://usaultimate.org/rules/#9.B.3.a">9.B.3.a</a> is called after a goal has been scored and prior to the ensuing pull, the other team may choose to nullify the goal and restart the point using re-pull timings (<a href="https://usaultimate.org/rules/#9.C.5.a">9.C.5.a</a>).
+                                            <a id="9.B.3.a.4">9.B.3.a.4.</a> If a violation of <a href="https://usaultimate.org/rules/#9.B.3.a">9.B.3.a</a> is called after a goal has been scored and prior to the ensuing pull, the other team may choose to nullify the goal and restart the point using re-pull timings (<a href="https://usaultimate.org/rules/#9.C.5.a">9.C.5.a</a>).
                                             <span class="annotation">[[A team must call a violation as soon as one is discovered; they may not wait to see the outcome of a point or play to call the violation (<a href="https://usaultimate.org/rules/#17.A">17.A</a>)]]</span>
                                         </li>
-                                    </ol>
+                                    </ul>
                                 </li>
-                            </ol>
+                            </ul>
                         </li>
 
                         <li>
-                            <a id="9.B.4"></a>Positioning before the <span class="tooltip" title="The throw from one team to the other that starts play at the beginning of a half or after a goal. It is not a legal pass for scoring and has many special provisions (Section 9.B). The player on the pulling team who possesses the disc and signals readiness is the puller.">pull</span>:
-                            <ol>
-                                <li><a id="9.B.4.a"></a>After signaling readiness, players on the pulling team may move anywhere in their end zone, but their feet may not break the vertical plane of the goal line until the disc is released.</li>
-                                <li><a id="9.B.4.b"></a>After signaling readiness, players on the receiving team must have one foot on the goal line that they are defending without changing location relative to one another.</li>
+                            <a id="9.B.4">9.B.4.</a> Positioning before the <span class="tooltip" title="The throw from one team to the other that starts play at the beginning of a half or after a goal. It is not a legal pass for scoring and has many special provisions (Section 9.B). The player on the pulling team who possesses the disc and signals readiness is the puller.">pull</span>:
+                            <ul>
+                                <li><a id="9.B.4.a">9.B.4.a.</a> After signaling readiness, players on the pulling team may move anywhere in their end zone, but their feet may not break the vertical plane of the goal line until the disc is released.</li>
+                                <li><a id="9.B.4.b">9.B.4.b.</a> After signaling readiness, players on the receiving team must have one foot on the goal line that they are defending without changing location relative to one another.</li>
                                 <li>
-                                    <a id="9.B.4.c"></a>After the disc is released, it is
+                                    <a id="9.B.4.c">9.B.4.c.</a> After the disc is released, it is
                                     <span class="tooltip" title="A disc is in play when players are allowed to move and play may proceed without the defense&#39;s acknowledgment. An in-bounds disc in the central zone is in play. The disc is subject to a turnover. If no player has possession of a disc in play, any offensive player may become the thrower by taking possession of the disc (14.A). Once a player has possession of the disc, they must establish a pivot at the spot of the disc 14.A.2) prior to attempting a pass (17.K).">in play</span>
                                     and any player may move in any direction.
                                 </li>
                                 <li>
-                                    <a id="9.B.4.d"></a>If a player on the pulling team fails to maintain proper positioning before the pull, the receiving team may call “offsides” before gaining possession of the disc. If a player on the receiving team fails to maintain proper positioning before the pull, the pulling team may call “false start” before the receiving team gains possession of the disc. The offsides and false start calls do not stop play, and the Continuation Rule (<a href="https://usaultimate.org/rules/#17.C">17.C</a>) does not apply.
+                                    <a id="9.B.4.d">9.B.4.d.</a> If a player on the pulling team fails to maintain proper positioning before the pull, the receiving team may call “offsides” before gaining possession of the disc. If a player on the receiving team fails to maintain proper positioning before the pull, the pulling team may call “false start” before the receiving team gains possession of the disc. The offsides and false start calls do not stop play, and the Continuation Rule (<a href="https://usaultimate.org/rules/#17.C">17.C</a>) does not apply.
                                     <span class="annotation">[[A sideline player or coach who is leaving the playing field with urgency but is still on the playing field when the disc is released is not considered to be offsides or committing a false start. If a sideline player or coach on the playing field impedes a player from the other team, that is a separate violation.]]</span>
                                     In games where observers are used, these calls can only be made by the observers. In games without observers, each team may send a designated sideline player to either goal line who has the ability to call “offsides” or “false start” or to offer their perspective on such a call. A contested offsides call results in a stoppage of play and a re-pull.
                                     <span class="annotation">[[To contest an offsides or false start call, a player on the contesting team must have perspective at least as good as the person making the call. If the call is made by a designated sideline player, only a similarly-positioned sideline player designated by the contesting team has equal or better perspective.]]</span>
-                                    <ol>
-                                        <li><a id="9.B.4.d.1"></a>In the first instance of offsides, the receiving team may let the disc hit the ground untouched and then take the disc at the brick mark closest to the end zone the receiving team is defending (following the same signaling procedure described in <a href="https://usaultimate.org/rules/#9.B.6.d.2">9.B.6.d.2</a>), even if the disc initially hits in-bounds, in addition to any other applicable options per <a href="https://usaultimate.org/rules/#9.B.6">9.B.6</a>–<a href="https://usaultimate.org/rules/#9.B.7">7</a>.</li>
+                                    <ul>
+                                        <li><a id="9.B.4.d.1">9.B.4.d.1.</a> In the first instance of offsides, the receiving team may let the disc hit the ground untouched and then take the disc at the brick mark closest to the end zone the receiving team is defending (following the same signaling procedure described in <a href="https://usaultimate.org/rules/#9.B.6.d.2">9.B.6.d.2</a>), even if the disc initially hits in-bounds, in addition to any other applicable options per <a href="https://usaultimate.org/rules/#9.B.6">9.B.6</a>–<a href="https://usaultimate.org/rules/#9.B.7">7</a>.</li>
                                         <li>
-                                            <a id="9.B.4.d.2"></a>After the first uncontested instance of offsides, in every subsequent instance of offsides, the receiving team may let the disc hit the ground untouched and then take the disc at midfield (by fully extending one hand overhead and calling “midfield” before gaining
+                                            <a id="9.B.4.d.2">9.B.4.d.2.</a> After the first uncontested instance of offsides, in every subsequent instance of offsides, the receiving team may let the disc hit the ground untouched and then take the disc at midfield (by fully extending one hand overhead and calling “midfield” before gaining
                                             <span class="tooltip" title="Sustained contact with, and control of, a non-spinning disc.">possession</span>
                                             of the disc) in addition to any other applicable options per
                                             <a href="https://usaultimate.org/rules/#9.B.6">9.B.6</a>–<a href="https://usaultimate.org/rules/#9.B.7">7</a>.
                                         </li>
-                                        <li><a id="9.B.4.d.3"></a>In any instance of false start, the pulling team may call “false start” prior to the receiving team taking possession of the disc. Play stops after the outcome of the pull is decided. Play resumes in a similar manner as after a team timeout. The player with possession of the disc (or any player on the offensive team if no player has possession) takes the disc to the spot on the playing field where the disc is to be put into play (per <a href="https://usaultimate.org/rules/#9.B.6">9.B.6</a>–<a href="https://usaultimate.org/rules/#9.B.7">7</a>). Ten seconds after the player in possession reaches that location, each offensive player must establish a stationary position. Movement after this time and before the disc is checked into play is a violation. The defense has twenty seconds after all offensive players have established their positions to check the disc into play.</li>
-                                        <li><a id="9.B.4.d.4"></a>If the pulling team is offsides and the receiving team commits a false start, the offense may put the disc into play at the appropriate spot for an offsides but may not attempt a pass until the disc is checked into play by the defense.</li>
-                                    </ol>
+                                        <li><a id="9.B.4.d.3">9.B.4.d.3.</a> In any instance of false start, the pulling team may call “false start” prior to the receiving team taking possession of the disc. Play stops after the outcome of the pull is decided. Play resumes in a similar manner as after a team timeout. The player with possession of the disc (or any player on the offensive team if no player has possession) takes the disc to the spot on the playing field where the disc is to be put into play (per <a href="https://usaultimate.org/rules/#9.B.6">9.B.6</a>–<a href="https://usaultimate.org/rules/#9.B.7">7</a>). Ten seconds after the player in possession reaches that location, each offensive player must establish a stationary position. Movement after this time and before the disc is checked into play is a violation. The defense has twenty seconds after all offensive players have established their positions to check the disc into play.</li>
+                                        <li><a id="9.B.4.d.4">9.B.4.d.4.</a> If the pulling team is offsides and the receiving team commits a false start, the offense may put the disc into play at the appropriate spot for an offsides but may not attempt a pass until the disc is checked into play by the defense.</li>
+                                    </ul>
                                 </li>
-                            </ol>
+                            </ul>
                         </li>
 
                         <li>
-                            <a id="9.B.5"></a>A player on the throwing team may not touch the
+                            <a id="9.B.5">9.B.5.</a> A player on the throwing team may not touch the
                             <span class="tooltip" title="The throw from one team to the other that starts play at the beginning of a half or after a goal. It is not a legal pass for scoring and has many special provisions (Section 9.B). The player on the pulling team who possesses the disc and signals readiness is the puller.">pull</span>
                             in the air before a member of the receiving team touches it. If this violation occurs, the receiving team may request a re-pull immediately.
                         </li>
                         <li>
-                            <a id="9.B.6"></a>If the
+                            <a id="9.B.6">9.B.6.</a> If the
                             <span class="tooltip" title="The throw from one team to the other that starts play at the beginning of a half or after a goal. It is not a legal pass for scoring and has many special provisions (Section 9.B). The player on the pulling team who possesses the disc and signals readiness is the puller.">pull</span>
                             hits the ground or an out-of-bounds area untouched, it is put into play as follows:
-                            <ol>
+                            <ul>
                                 <li>
-                                    <a id="9.B.6.a"></a>If the disc initially hits and remains in-bounds, it is
+                                    <a id="9.B.6.a">9.B.6.a.</a> If the disc initially hits and remains in-bounds, it is
                                     <span class="tooltip" title="A disc is in play when players are allowed to move and play may proceed without the defense&#39;s acknowledgment. An in-bounds disc in the central zone is in play. The disc is subject to a turnover. If no player has possession of a disc in play, any offensive player may become the thrower by taking possession of the disc (14.A). Once a player has possession of the disc, they must establish a pivot at the spot of the disc 14.A.2) prior to attempting a pass (17.K).">in play</span>
                                     where it comes to rest or is stopped (<a href="https://usaultimate.org/rules/#17.F">17.F</a>).
                                 </li>
-                                <li><a id="9.B.6.b"></a>If the disc initially hits in-bounds and then becomes out-of-bounds before being touched by the receiving team, it is put into play at the spot on the central zone (i.e., excluding the end zones) nearest to where it first crossed the perimeter line to become out-of-bounds.</li>
-                                <li><a id="9.B.6.c"></a>If the disc initially hits in-bounds and then becomes out-of-bounds after being touched by the receiving team, it is put into play at the spot on the playing field nearest to where it first crossed the perimeter line to become out-of-bounds.</li>
+                                <li><a id="9.B.6.b">9.B.6.b.</a> If the disc initially hits in-bounds and then becomes out-of-bounds before being touched by the receiving team, it is put into play at the spot on the central zone (i.e., excluding the end zones) nearest to where it first crossed the perimeter line to become out-of-bounds.</li>
+                                <li><a id="9.B.6.c">9.B.6.c.</a> If the disc initially hits in-bounds and then becomes out-of-bounds after being touched by the receiving team, it is put into play at the spot on the playing field nearest to where it first crossed the perimeter line to become out-of-bounds.</li>
                                 <li>
-                                    <a id="9.B.6.d"></a>If the disc initially hits an out-of-bounds area, the receiving team may put the disc into play:
-                                    <ol>
-                                        <li><a id="9.B.6.d.1"></a>at the spot determined by <a href="https://usaultimate.org/rules/#10.H">10.H</a>; or</li>
+                                    <a id="9.B.6.d">9.B.6.d.</a> If the disc initially hits an out-of-bounds area, the receiving team may put the disc into play:
+                                    <ul>
+                                        <li><a id="9.B.6.d.1">9.B.6.d.1.</a> at the spot determined by <a href="https://usaultimate.org/rules/#10.H">10.H</a>; or</li>
                                         <li>
-                                            <a id="9.B.6.d.2"></a>after signaling for a brick or middle by fully extending one hand overhead and calling brick or middle before gaining
+                                            <a id="9.B.6.d.2">9.B.6.d.2.</a> after signaling for a brick or middle by fully extending one hand overhead and calling brick or middle before gaining
                                             <span class="tooltip" title="Sustained contact with, and control of, a non-spinning disc.">possession</span>
                                             of the disc, either at
-                                            <ol>
-                                                <li><a id="9.B.6.d.2.a"></a>the brick mark closest to the end zone that the receiving team is defending if “brick” was called, or</li>
-                                                <li><a id="9.B.6.d.2.a"></a>the spot on the long axis of the central zone nearest to the spot determined by 10.H if “middle” was called.</li>
-                                            </ol>
+                                            <ul>
+                                                <li><a id="9.B.6.d.2.a">9.B.6.d.2.a.</a> the brick mark closest to the end zone that the receiving team is defending if “brick” was called, or</li>
+                                                <li><a id="9.B.6.d.2.a">9.B.6.d.2.a.</a> the spot on the long axis of the central zone nearest to the spot determined by 10.H if “middle” was called.</li>
+                                            </ul>
                                         </li>
-                                    </ol>
+                                    </ul>
                                 </li>
-                            </ol>
+                            </ul>
                         </li>
 
                         <li>
-                            <a id="9.B.7"></a>If the
+                            <a id="9.B.7">9.B.7.</a> If the
                             <span class="tooltip" title="The throw from one team to the other that starts play at the beginning of a half or after a goal. It is not a legal pass for scoring and has many special provisions (Section 9.B). The player on the pulling team who possesses the disc and signals readiness is the puller.">pull</span>
                             is caught on the playing field, the disc is
                             <span class="tooltip" title="A disc is in play when players are allowed to move and play may proceed without the defense&#39;s acknowledgment. An in-bounds disc in the central zone is in play. The disc is subject to a turnover. If no player has possession of a disc in play, any offensive player may become the thrower by taking possession of the disc (14.A). Once a player has possession of the disc, they must establish a pivot at the spot of the disc 14.A.2) prior to attempting a pass (17.K).">in play</span>
                             where it was caught. If the disc is caught outside the playing field, the disc is put into play at the spot on the playing field nearest to where it was caught.
                         </li>
                         <li>
-                            <a id="9.B.8"></a>If a player on the receiving team touches the
+                            <a id="9.B.8">9.B.8.</a> If a player on the receiving team touches the
                             <span class="tooltip" title="The throw from one team to the other that starts play at the beginning of a half or after a goal. It is not a legal pass for scoring and has many special provisions (Section 9.B). The player on the pulling team who possesses the disc and signals readiness is the puller.">pull</span>
                             before it hits the ground and the disc then hits the ground, it is considered a dropped disc (<a href="https://usaultimate.org/rules/#13.B">13.B</a>) and results in a turnover.
                         </li>
                         <li>
-                            <a id="9.B.9"></a>After a <span class="tooltip" title="The throw from one team to the other that starts play at the beginning of a half or after a goal. It is not a legal pass for scoring and has many special provisions (Section 9.B). The player on the pulling team who possesses the disc and signals readiness is the puller.">pull</span>, whichever player takes
+                            <a id="9.B.9">9.B.9.</a> After a <span class="tooltip" title="The throw from one team to the other that starts play at the beginning of a half or after a goal. It is not a legal pass for scoring and has many special provisions (Section 9.B). The player on the pulling team who possesses the disc and signals readiness is the puller.">pull</span>, whichever player takes
                             <span class="tooltip" title="Sustained contact with, and control of, a non-spinning disc.">possession</span>
                             of the disc must put it into play. If a player drops the disc while carrying it to the spot where it is to be put into play and it contacts the ground before the thrower regains possession, the other team gains possession of the disc at the spot on the central zone nearest to the drop.
                         </li>
                         <li>
-                            <a id="9.B.10"></a>There is no
+                            <a id="9.B.10">9.B.10.</a> There is no
                             <span class="tooltip" title="Any halting of play due to a call, discussion, or timeout that requires a check or self-check to restart play. The term play stops means a stoppage of play occurs.">stoppage of play</span>
                             when putting the
                             <span class="tooltip" title="The throw from one team to the other that starts play at the beginning of a half or after a goal. It is not a legal pass for scoring and has many special provisions (Section 9.B). The player on the pulling team who possesses the disc and signals readiness is the puller.">pull</span>
@@ -879,146 +884,146 @@
                             <span class="tooltip" title="A disc is live when players are allowed to move and the disc is subject to a turnover, but the thrower cannot make a legal pass (e.g., walking the disc to the spot where it is to be put into play). For a live disc to be put into play, the thrower must (1) establish a pivot at the appropriate spot on the field, and (2) touch the disc to the ground (14.B).">live</span>
                             and the thrower must touch the disc to the ground after establishing a pivot at the appropriate spot on the playing field before attempting a pass.
                         </li>
-                    </ol>
+                    </ul>
                 </li>
 
                 <li>
-                    <a id="9.C"></a>Time between <span class="tooltip" title="The throw from one team to the other that starts play at the beginning of a half or after a goal. It is not a legal pass for scoring and has many special provisions (Section 9.B). The player on the pulling team who possesses the disc and signals readiness is the puller.">pull</span>s:
-                    <ol>
-                        <li><a id="9.C.1"></a>For the times listed below, if there is a call or dispute surrounding the goal-scoring play, the timer begins after the call or dispute has been resolved (if the resolution results in a goal being awarded). <span class="annotation">[[The timer is not retroactive to the time of the goal-scoring catch. This is in contrast to determining when time caps go into effect, which is retroactive to the goal-scoring catch.]]</span></li>
+                    <a id="9.C">9.C.</a> Time between <span class="tooltip" title="The throw from one team to the other that starts play at the beginning of a half or after a goal. It is not a legal pass for scoring and has many special provisions (Section 9.B). The player on the pulling team who possesses the disc and signals readiness is the puller.">pull</span>s:
+                    <ul>
+                        <li><a id="9.C.1">9.C.1.</a> For the times listed below, if there is a call or dispute surrounding the goal-scoring play, the timer begins after the call or dispute has been resolved (if the resolution results in a goal being awarded). <span class="annotation">[[The timer is not retroactive to the time of the goal-scoring catch. This is in contrast to determining when time caps go into effect, which is retroactive to the goal-scoring catch.]]</span></li>
                         <li>
-                            <a id="9.C.2"></a>In mixed gender play, the team responsible for signaling the gender ratio for the upcoming point must do so within twenty five (25) seconds after the previous goal was scored.
+                            <a id="9.C.2">9.C.2.</a> In mixed gender play, the team responsible for signaling the gender ratio for the upcoming point must do so within twenty five (25) seconds after the previous goal was scored.
                             <span class="annotation">[[The team responsible for signaling gender is encouraged to signal as early as possible after the previous goal is scored, but must do so no later than 25 seconds.]]</span>
                         </li>
                         <li>
-                            <a id="9.C.3"></a>Within fifty (50) seconds after the previous goal was scored, the receiving team must line up for the purpose of allowing the pulling team to match up defensively. Each player must place one foot on the goal line, be visible to the pulling team, and not change their relative position on the line.
-                            <ol>
+                            <a id="9.C.3">9.C.3.</a> Within fifty (50) seconds after the previous goal was scored, the receiving team must line up for the purpose of allowing the pulling team to match up defensively. Each player must place one foot on the goal line, be visible to the pulling team, and not change their relative position on the line.
+                            <ul>
                                 <li>
-                                    <a id="9.C.3.a"></a>Other
+                                    <a id="9.C.3.a">9.C.3.a.</a> Other
                                     <span class="tooltip" title="Any person designated by the team, to the event organizer, to be officially associated with the team, per the rules established by the event organizer.">team members</span>
                                     (<span class="tooltip" title="A team member who has been officially recognized by event organizers to have met the requirements necessary for coaching, including but not limited to certification, screening, education, and registration. Coaches are permitted in areas where sideline players are allowed, during and between points, in accordance with event rules. Coaches are not permitted to make calls or contribute to the discussion or resolution of calls, except to clarify rules if requested.">coaches</span>, <span class="tooltip" title="A team member who has been officially recognized by event organizers to be a member of the team for a specific support purpose. Team support staff are generally permitted in areas where sideline players are allowed, but may be further restricted by event rules.">support staff</span>,
                                     <span class="tooltip" title="Any team member who is present at the field and eligible to participate in the game, but who is not a player participating in the current point.">sideline players</span>) may be present on the field during this time.
                                 </li>
-                            </ol>
+                            </ul>
                         </li>
 
                         <li>
-                            <a id="9.C.4"></a>Within sixty (60) seconds after the previous goal was scored, the receiving team must signal readiness (<a href="https://usaultimate.org/rules/#9.B.3">9.B.3</a>).
-                            <ol>
+                            <a id="9.C.4">9.C.4.</a> Within sixty (60) seconds after the previous goal was scored, the receiving team must signal readiness (<a href="https://usaultimate.org/rules/#9.B.3">9.B.3</a>).
+                            <ul>
                                 <li>
-                                    <a id="9.C.3.a"></a>All other
+                                    <a id="9.C.3.a">9.C.3.a.</a> All other
                                     <span class="tooltip" title="Any person designated by the team, to the event organizer, to be officially associated with the team, per the rules established by the event organizer.">team members</span>
                                     must be clear of the field at this time.
                                 </li>
-                            </ol>
+                            </ul>
                         </li>
 
                         <li>
-                            <a id="9.C.5"></a>The pulling team must release the
+                            <a id="9.C.5">9.C.5.</a> The pulling team must release the
                             <span class="tooltip" title="The throw from one team to the other that starts play at the beginning of a half or after a goal. It is not a legal pass for scoring and has many special provisions (Section 9.B). The player on the pulling team who possesses the disc and signals readiness is the puller.">pull</span>
                             before the later to occur of:
-                            <ol>
-                                <li><a id="9.C.5.a"></a>eighty (80) seconds after the previous goal was scored; or</li>
-                                <li><a id="9.C.5.b"></a>thirty (30) seconds after the receiving team lined up; or</li>
-                                <li><a id="9.C.5.c"></a>twenty (20) seconds after the receiving team signaled readiness.</li>
-                            </ol>
+                            <ul>
+                                <li><a id="9.C.5.a">9.C.5.a.</a> eighty (80) seconds after the previous goal was scored; or</li>
+                                <li><a id="9.C.5.b">9.C.5.b.</a> thirty (30) seconds after the receiving team lined up; or</li>
+                                <li><a id="9.C.5.c">9.C.5.c.</a> twenty (20) seconds after the receiving team signaled readiness.</li>
+                            </ul>
                         </li>
 
                         <li>
-                            <a id="9.C.6"></a>On a re-pull,
-                            <ol>
-                                <li><a id="9.C.6.a"></a>the receiving team must signal readiness to play within twenty (20) seconds after the call for a re-pull was made; and</li>
+                            <a id="9.C.6">9.C.6.</a> On a re-pull,
+                            <ul>
+                                <li><a id="9.C.6.a">9.C.6.a.</a> the receiving team must signal readiness to play within twenty (20) seconds after the call for a re-pull was made; and</li>
                                 <li>
-                                    <a id="9.C.6.b"></a>the pulling team must release the
+                                    <a id="9.C.6.b">9.C.6.b.</a> the pulling team must release the
                                     <span class="tooltip" title="The throw from one team to the other that starts play at the beginning of a half or after a goal. It is not a legal pass for scoring and has many special provisions (Section 9.B). The player on the pulling team who possesses the disc and signals readiness is the puller.">pull</span>
                                     before the later to occur of:
-                                    <ol>
-                                        <li><a id="9.C.6.b.1"></a>forty (40) seconds after the call for a re-pull was made; or</li>
-                                        <li><a id="9.C.6.b.2"></a>twenty (20) seconds after the receiving team signaled readiness.</li>
-                                    </ol>
+                                    <ul>
+                                        <li><a id="9.C.6.b.1">9.C.6.b.1.</a> forty (40) seconds after the call for a re-pull was made; or</li>
+                                        <li><a id="9.C.6.b.2">9.C.6.b.2.</a> twenty (20) seconds after the receiving team signaled readiness.</li>
+                                    </ul>
                                 </li>
-                            </ol>
+                            </ul>
                         </li>
 
                         <li>
-                            <a id="9.C.7"></a>In games where
+                            <a id="9.C.7">9.C.7.</a> In games where
                             <span class="tooltip" title="Observers are non-player game officials whose job is to support the players in implementing a safe, fair, and efficient game. Observers carefully watch the action of the game, assist with communication, help uphold self-officiating and the Spirit of the Game, assist with resolving calls as needed, and perform other duties as described in Section 19">observers</span>
                             are used, the observers may monitor and call time violations as appropriate. The first instance of a time violation for each team will result in a warning. After a team has received its warning, any further time violations will result in assessment of a team timeout (and the resulting time extensions). If a team has no timeouts remaining, time violations are treated as follows:
-                            <ol>
-                                <li><a id="9.C.7.a"></a>Time violation on receiving team: the receiving team starts with the disc at the midpoint of the end zone they are defending, after players set up and a check is performed.</li>
-                                <li><a id="9.C.7.b"></a>Time violation on pulling team: the receiving team starts with the disc at midfield, after players set up and a check is performed.</li>
-                            </ol>
+                            <ul>
+                                <li><a id="9.C.7.a">9.C.7.a.</a> Time violation on receiving team: the receiving team starts with the disc at the midpoint of the end zone they are defending, after players set up and a check is performed.</li>
+                                <li><a id="9.C.7.b">9.C.7.b.</a> Time violation on pulling team: the receiving team starts with the disc at midfield, after players set up and a check is performed.</li>
+                            </ul>
                         </li>
 
                         <li>
-                            <a id="9.C.8"></a>In games where the participants require more time (youth, beginner, or other levels), team
+                            <a id="9.C.8">9.C.8.</a> In games where the participants require more time (youth, beginner, or other levels), team
                             <span class="tooltip" title="A team member, who is eligible to participate in the game, and has been designated to represent the team in decision-making on behalf of the team before, during, and after a game.">captains</span>
                             or tournament organizers (as appropriate) are encouraged to extend the time limits listed above to best suit the level of play.
                         </li>
-                    </ol>
+                    </ul>
                 </li>
 
                 <li>
-                    <a id="9.D"></a>Check:
-                    <ol>
+                    <a id="9.D">9.D.</a> Check:
+                    <ul>
                         <li>
-                            <a id="9.D.1"></a>When play stops, each player must come to a stop as quickly as possible. Before restarting play, all players must assume the location on the field specified by the rule that covers that specific
+                            <a id="9.D.1">9.D.1.</a> When play stops, each player must come to a stop as quickly as possible. Before restarting play, all players must assume the location on the field specified by the rule that covers that specific
                             <span class="tooltip" title="Any halting of play due to a call, discussion, or timeout that requires a check or self-check to restart play. The term play stops means a stoppage of play occurs.">stoppage of play</span>
                             and remain there until play is restarted.
                         </li>
-                        <li><a id="9.D.2"></a>If a called infraction occurs while play is stopped, any subsequent play is negated and players must assume their appropriate locations under <a href="https://usaultimate.org/rules/#9.D.1">9.D.1</a>. This called infraction does not alter the stall count.<span class="annotation">[[Thus any pass attempted will be returned to the thrower.]]</span></li>
+                        <li><a id="9.D.2">9.D.2.</a> If a called infraction occurs while play is stopped, any subsequent play is negated and players must assume their appropriate locations under <a href="https://usaultimate.org/rules/#9.D.1">9.D.1</a>. This called infraction does not alter the stall count.<span class="annotation">[[Thus any pass attempted will be returned to the thrower.]]</span></li>
                         <li>
-                            <a id="9.D.3"></a>When the situation is resolved, the player determined to be in possession offers the disc to the
+                            <a id="9.D.3">9.D.3.</a> When the situation is resolved, the player determined to be in possession offers the disc to the
                             <span class="tooltip" title="The defensive player within ten feet of the thrower&#39;s pivot or of the thrower if no pivot has been established. If the disc is not in a player&#39;s possession, a defensive player within ten feet of a spot on the field where the disc is to be put into play is considered the marker.">marker</span>
                             for a check.
-                            <ol>
-                                <li><a id="9.D.3.a"></a>The <span class="tooltip" title="The defensive player within ten feet of the thrower&#39;s pivot or of the thrower if no pivot has been established. If the disc is not in a player&#39;s possession, a defensive player within ten feet of a spot on the field where the disc is to be put into play is considered the marker.">marker</span> restarts play by loudly announcing “3-2-1,” touching the disc in the thrower's possession, and announcing “disc in.” If the thrower attempts a pass before the marker touches the disc, the pass (whether complete or incomplete) does not count and the thrower regains possession.</li>
-                                <li><a id="9.D.3.b"></a>Any stall count in effect resumes according to <a href="https://usaultimate.org/rules/#15.A.5">15.A.5</a>.</li>
-                            </ol>
+                            <ul>
+                                <li><a id="9.D.3.a">9.D.3.a.</a> The <span class="tooltip" title="The defensive player within ten feet of the thrower&#39;s pivot or of the thrower if no pivot has been established. If the disc is not in a player&#39;s possession, a defensive player within ten feet of a spot on the field where the disc is to be put into play is considered the marker.">marker</span> restarts play by loudly announcing “3-2-1,” touching the disc in the thrower's possession, and announcing “disc in.” If the thrower attempts a pass before the marker touches the disc, the pass (whether complete or incomplete) does not count and the thrower regains possession.</li>
+                                <li><a id="9.D.3.b">9.D.3.b.</a> Any stall count in effect resumes according to <a href="https://usaultimate.org/rules/#15.A.5">15.A.5</a>.</li>
+                            </ul>
                         </li>
 
                         <li>
-                            <a id="9.D.4"></a>Offensive self-check: If play is to restart with a check, but no
+                            <a id="9.D.4">9.D.4.</a> Offensive self-check: If play is to restart with a check, but no
                             <span class="tooltip" title="A player whose team is not in possession of the disc. A defensive player may not pick up a live disc or a disc in play or call for a pass from the thrower.">defensive player</span>
                             is near enough to touch the disc in the thrower's hand, play restarts with an offensive self-check. To restart play using an offensive self-check:
                             <span class="annotation">[[Determine this distance based on the thrower standing upright and extending the disc toward the <span class="tooltip" title="The defensive player within ten feet of the thrower&#39;s pivot or of the thrower if no pivot has been established. If the disc is not in a player&#39;s possession, a defensive player within ten feet of a spot on the field where the disc is to be put into play is considered the marker.">marker</span>.]]</span>
-                            <ol>
-                                <li><a id="9.D.4.a"></a>the defense must acknowledge readiness; and</li>
-                                <li><a id="9.D.4.b"></a>the thrower establishes a pivot at the appropriate spot on the field, loudly announces “3-2-1,” touches the disc to the ground, and loudly announces “disc in.”</li>
-                            </ol>
+                            <ul>
+                                <li><a id="9.D.4.a">9.D.4.a.</a> the defense must acknowledge readiness; and</li>
+                                <li><a id="9.D.4.b">9.D.4.b.</a> the thrower establishes a pivot at the appropriate spot on the field, loudly announces “3-2-1,” touches the disc to the ground, and loudly announces “disc in.”</li>
+                            </ul>
                         </li>
 
                         <li>
-                            <a id="9.D.5"></a>Defensive self-check: If play is to restart with a check, but no
+                            <a id="9.D.5">9.D.5.</a> Defensive self-check: If play is to restart with a check, but no
                             <span class="tooltip" title="A player whose team is in possession of the disc.">offensive player</span>
                             is in possession of the disc at the appropriate spot, play restarts with a defensive self-check. To restart play using a defensive self-check:
-                            <ol>
-                                <li><a id="9.D.5.a"></a>the disc is placed at the appropriate spot on the field;</li>
-                                <li><a id="9.D.5.b"></a>the offense must acknowledge readiness; and</li>
-                                <li><a id="9.D.5.c"></a>the defender closest to the disc loudly announces “3-2-1 disc in.”</li>
-                            </ol>
+                            <ul>
+                                <li><a id="9.D.5.a">9.D.5.a.</a> the disc is placed at the appropriate spot on the field;</li>
+                                <li><a id="9.D.5.b">9.D.5.b.</a> the offense must acknowledge readiness; and</li>
+                                <li><a id="9.D.5.c">9.D.5.c.</a> the defender closest to the disc loudly announces “3-2-1 disc in.”</li>
+                            </ul>
                         </li>
-                    </ol>
+                    </ul>
                 </li>
-            </ol>
+            </ul>
         </li>
 
         <li>
-            <a id="10"></a>In- and Out-of-bounds
-            <ol>
-                <li><a id="10.A"></a>The entire playing field is in-bounds. The perimeter lines are not part of the playing field and are out-of-bounds.</li>
+            <a id="10">10.</a> In- and Out-of-bounds
+            <ul>
+                <li><a id="10.A">10.A.</a> The entire playing field is in-bounds. The perimeter lines are not part of the playing field and are out-of-bounds.</li>
                 <li>
-                    <a id="10.B"></a>The out-of-bounds area consists of the ground which is not in-bounds and everything in contact (direct or indirect) with it except for players. Any
+                    <a id="10.B">10.B.</a> The out-of-bounds area consists of the ground which is not in-bounds and everything in contact (direct or indirect) with it except for players. Any
                     <span class="tooltip" title="Any person who is not a player or sideline player as defined in these rules.">non-players</span>
                     other than
                     <span class="tooltip" title="Observers are non-player game officials whose job is to support the players in implementing a safe, fair, and efficient game. Observers carefully watch the action of the game, assist with communication, help uphold self-officiating and the Spirit of the Game, assist with resolving calls as needed, and perform other duties as described in Section 19">observers</span>
                     are considered part of the out-of-bounds area. A disc does not change in- or out-of-bounds status when contacted by an observer.
                 </li>
                 <li>
-                    <a id="10.C"></a>A player contacting the out-of-bounds area is out-of-bounds. A player who is not out-of-bounds is in-bounds. An airborne player retains in-bounds or out-of-bounds status until that player contacts the playing field or the out-of-bounds area. The following exceptions apply:
-                    <ol>
+                    <a id="10.C">10.C.</a> A player contacting the out-of-bounds area is out-of-bounds. A player who is not out-of-bounds is in-bounds. An airborne player retains in-bounds or out-of-bounds status until that player contacts the playing field or the out-of-bounds area. The following exceptions apply:
+                    <ul>
                         <li>
-                            <a id="10.C.1"></a>If momentum carries a player out-of-bounds after landing in-bounds with
+                            <a id="10.C.1">10.C.1.</a> If momentum carries a player out-of-bounds after landing in-bounds with
                             <span class="tooltip" title="Sustained contact with, and control of, a non-spinning disc.">possession</span>
                             of an in-bounds disc, the player is considered in-bounds. For this exception to apply, that player's first point of
                             <span class="tooltip" title="All player contact with the ground directly related to a specific event or maneuver (e.g., jumping, diving, leaning or falling), including landing or recovering after being off-balance. Items on the ground are considered part of the ground.">ground contact</span>
@@ -1026,82 +1031,82 @@
                             <a href="https://usaultimate.org/rules/#11.A.2">11.A.2</a> applies). If the player traversed the end zone being attacked, <a href="https://usaultimate.org/rules/#11.B">11.B</a> applies.
                         </li>
                         <li>
-                            <a id="10.C.2"></a>A pivoting thrower may contact an out-of-bounds area, provided that part of the pivot remains in contact with the playing field.
+                            <a id="10.C.2">10.C.2.</a> A pivoting thrower may contact an out-of-bounds area, provided that part of the pivot remains in contact with the playing field.
                             <span class="annotation">[[In this case, the player and the disc are considered in-bounds.]]</span>
                         </li>
-                        <li><a id="10.C.3"></a>Contact between players does not confer the state of being in- or out-of-bounds from one to another.</li>
-                        <li><a id="#10.C.4"></a>If a player catches an in-bounds disc and would reasonably have been able to land in-bounds, but lands on an opposing player in a way that causes their first ground contact to be out-of-bounds, this is to be treated as a force-out foul and <a href="https://usaultimate.org/rules/#17.I.4.b.4">17.I.4.b.4</a> applies. For this exception to apply, the play resulting in the landing contact cannot be construed as a <a href="https://usaultimate.org/rules/#17.I.1">dangerous play</a>. <span class="annotation">[[In this case, calls will be resolved in chronological order with the dangerous play superseding the force-out foul.]]</span></li>
-                    </ol>
+                        <li><a id="10.C.3">10.C.3.</a> Contact between players does not confer the state of being in- or out-of-bounds from one to another.</li>
+                        <li><a id="#10.C.4">#10.C.4.</a> If a player catches an in-bounds disc and would reasonably have been able to land in-bounds, but lands on an opposing player in a way that causes their first ground contact to be out-of-bounds, this is to be treated as a force-out foul and <a href="https://usaultimate.org/rules/#17.I.4.b.4">17.I.4.b.4</a> applies. For this exception to apply, the play resulting in the landing contact cannot be construed as a <a href="https://usaultimate.org/rules/#17.I.1">dangerous play</a>. <span class="annotation">[[In this case, calls will be resolved in chronological order with the dangerous play superseding the force-out foul.]]</span></li>
+                    </ul>
                 </li>
 
-                <li><a id="10.D"></a>A disc becomes in-bounds when it is put into play, or when play starts or restarts.</li>
-                <li><a id="10.E"></a>A disc becomes out-of-bounds when it first contacts the out-of-bounds area, contacts an out-of-bounds <span class="tooltip" title="A player whose team is in possession of the disc.">offensive player</span>, or is caught by an out-of-bounds <span class="tooltip" title="A player whose team is not in possession of the disc. A defensive player may not pick up a live disc or a disc in play or call for a pass from the thrower.">defensive player</span>.</li>
-                <li><a id="10.F"></a>The disc may fly outside a perimeter line and return to the playing field, and players may go out-of-bounds to make a play on the disc.</li>
+                <li><a id="10.D">10.D.</a> A disc becomes in-bounds when it is put into play, or when play starts or restarts.</li>
+                <li><a id="10.E">10.E.</a> A disc becomes out-of-bounds when it first contacts the out-of-bounds area, contacts an out-of-bounds <span class="tooltip" title="A player whose team is in possession of the disc.">offensive player</span>, or is caught by an out-of-bounds <span class="tooltip" title="A player whose team is not in possession of the disc. A defensive player may not pick up a live disc or a disc in play or call for a pass from the thrower.">defensive player</span>.</li>
+                <li><a id="10.F">10.F.</a> The disc may fly outside a perimeter line and return to the playing field, and players may go out-of-bounds to make a play on the disc.</li>
                 <li>
-                    <a id="10.G"></a>If an in-bounds defender gains
+                    <a id="10.G">10.G.</a> If an in-bounds defender gains
                     <span class="tooltip" title="Sustained contact with, and control of, a non-spinning disc.">possession</span>
                     while airborne and becomes out-of-bounds while still in possession of the disc, the play is treated as if the defender was out-of-bounds when possession was gained (<a href="https://usaultimate.org/rules/#10.E">10.E</a>).
                 </li>
                 <li>
-                    <a id="10.H"></a>To continue play after the disc becomes out-of-bounds, a member of the team gaining possession of the disc must carry it to, and put it into play at, the spot on the central zone nearest to where the most recent of the following events occurred:
-                    <ol>
-                        <li><a id="10.H.1"></a>the disc completely crossed the perimeter line;</li>
-                        <li><a id="10.H.2"></a>the disc contacted an in-bounds player;</li>
-                        <li><a id="10.H.3"></a>the disc contacted a <span class="tooltip" title="A player whose team is not in possession of the disc. A defensive player may not pick up a live disc or a disc in play or call for a pass from the thrower.">defensive player</span>; or</li>
-                        <li><a id="10.H.4"></a>the disc became out-of-bounds due to contact with the out-of-bounds area or a player while any part of the disc was inside the perimeter line.</li>
-                    </ol>
+                    <a id="10.H">10.H.</a> To continue play after the disc becomes out-of-bounds, a member of the team gaining possession of the disc must carry it to, and put it into play at, the spot on the central zone nearest to where the most recent of the following events occurred:
+                    <ul>
+                        <li><a id="10.H.1">10.H.1.</a> the disc completely crossed the perimeter line;</li>
+                        <li><a id="10.H.2">10.H.2.</a> the disc contacted an in-bounds player;</li>
+                        <li><a id="10.H.3">10.H.3.</a> the disc contacted a <span class="tooltip" title="A player whose team is not in possession of the disc. A defensive player may not pick up a live disc or a disc in play or call for a pass from the thrower.">defensive player</span>; or</li>
+                        <li><a id="10.H.4">10.H.4.</a> the disc became out-of-bounds due to contact with the out-of-bounds area or a player while any part of the disc was inside the perimeter line.</li>
+                    </ul>
 
                     After establishing a pivot at the appropriate spot on the field, the thrower must touch the disc to the ground before putting it into play (<a href="https://usaultimate.org/rules/#14.B">14.B</a>).
                 </li>
 
-                <li><a id="10.I"></a>Events occurring after the disc becomes out-of-bounds do not affect where it is put into play.</li>
-            </ol>
+                <li><a id="10.I">10.I.</a> Events occurring after the disc becomes out-of-bounds do not affect where it is put into play.</li>
+            </ul>
         </li>
 
         <li>
-            <a id="11"></a>End Zone Possession
-            <ol>
+            <a id="11">11.</a> End Zone Possession
+            <ul>
                 <li>
-                    <a id="11.A"></a>If a turnover results in a team gaining possession in the end zone that they are defending, the player in possession must immediately either:
-                    <ol>
+                    <a id="11.A">11.A.</a> If a turnover results in a team gaining possession in the end zone that they are defending, the player in possession must immediately either:
+                    <ul>
                         <li>
-                            <a id="11.A.1"></a>establish a pivot at the spot of the disc (to fake a throw or pause after gaining
+                            <a id="11.A.1">11.A.1.</a> establish a pivot at the spot of the disc (to fake a throw or pause after gaining
                             <span class="tooltip" title="Sustained contact with, and control of, a non-spinning disc.">possession</span>
                             commits the player to put the disc into play at that spot); or
                         </li>
                         <li>
-                            <a id="11.A.2"></a>carry the disc directly to the closest point on the goal line and put it into play at that spot. If this option is chosen, the player taking possession must put the disc into play at the goal line.
+                            <a id="11.A.2">11.A.2.</a> carry the disc directly to the closest point on the goal line and put it into play at that spot. If this option is chosen, the player taking possession must put the disc into play at the goal line.
                             <span class="annotation">[[The player may carry the disc at any speed, constant or variable, while not unreasonably delaying.]]</span>
                             Failure to do so is a travel.
                             <span class="annotation">[[The player must put the disc into play either at the spot of the disc or on the goal line, not in between.]]</span>
                         </li>
-                    </ol>
+                    </ul>
                 </li>
 
-                <li><a id="11.B"></a>If a team gains or retains possession in the end zone that they are attacking other than by scoring a goal in accordance with rule <a href="https://usaultimate.org/rules/#12">12</a>, the player in possession must carry the disc directly to, and put it into play at, the spot on the goal line closest to where the player stopped.</li>
+                <li><a id="11.B">11.B.</a> If a team gains or retains possession in the end zone that they are attacking other than by scoring a goal in accordance with rule <a href="https://usaultimate.org/rules/#12">12</a>, the player in possession must carry the disc directly to, and put it into play at, the spot on the goal line closest to where the player stopped.</li>
                 <li>
-                    <a id="11.C"></a>If a team gains or retains possession of a
+                    <a id="11.C">11.C.</a> If a team gains or retains possession of a
                     <span class="tooltip" title="A disc is dead when play has stopped and can continue only with a check (see 9.D). The disc is not subject to a turnover. A dead disc may change states to either live or in play after a check depending on the circumstances.">dead</span>
                     disc in the end zone that they are attacking, the disc is checked into a
                     <span class="tooltip" title="A disc is live when players are allowed to move and the disc is subject to a turnover, but the thrower cannot make a legal pass (e.g., walking the disc to the spot where it is to be put into play). For a live disc to be put into play, the thrower must (1) establish a pivot at the appropriate spot on the field, and (2) touch the disc to the ground (14.B).">live</span>
                     state where the infraction occurred, and the thrower then proceeds according to <a href="https://usaultimate.org/rules/#11.B">11.B</a>.
                     <span class="annotation">[[For example, after an uncontested receiving foul.]]</span>
                 </li>
-            </ol>
+            </ul>
         </li>
 
         <li>
-            <a id="12"></a>Scoring
-            <ol>
+            <a id="12">12.</a> Scoring
+            <ul>
                 <li>
-                    <a id="12.A"></a>A goal is scored when an in-bounds player catches any legal pass in the end zone of attack, and retains
+                    <a id="12.A">12.A.</a> A goal is scored when an in-bounds player catches any legal pass in the end zone of attack, and retains
                     <span class="tooltip" title="Sustained contact with, and control of, a non-spinning disc.">possession</span>
                     of the disc throughout all
                     <span class="tooltip" title="All player contact with the ground directly related to a specific event or maneuver (e.g., jumping, diving, leaning or falling), including landing or recovering after being off-balance. Items on the ground are considered part of the ground.">ground contact</span>
                     related to the catch.
-                    <ol>
+                    <ul>
                         <li>
-                            <a id="12.A.1"></a>To be considered in the end zone after gaining
+                            <a id="12.A.1">12.A.1.</a> To be considered in the end zone after gaining
                             <span class="tooltip" title="Sustained contact with, and control of, a non-spinning disc.">possession</span>
                             of the disc in accordance with
                             <a href="https://usaultimate.org/rules/#3.J.2">3.J.2</a> and <a href="https://usaultimate.org/rules/#16.E">16.E</a>, the player's first point of
@@ -1111,44 +1116,44 @@
                             <span class="annotation">[[Remember, the end zone line is not part of the end zone.]]</span>
                         </li>
                         <li>
-                            <a id="12.A.2"></a>When an in-bounds player in possession of the disc whose first
+                            <a id="12.A.2">12.A.2.</a> When an in-bounds player in possession of the disc whose first
                             <span class="tooltip" title="All player contact with the ground directly related to a specific event or maneuver (e.g., jumping, diving, leaning or falling), including landing or recovering after being off-balance. Items on the ground are considered part of the ground.">ground contact</span>
                             will be completely within the end zone loses
                             <span class="tooltip" title="Sustained contact with, and control of, a non-spinning disc.">possession</span>
                             of the disc due to an uncontested
                             <span class="tooltip" title="Non-Incidental contact: contact between opposing players (see 3.F for a definition of incidental contact). In general, the player initiating the contact has committed the foul.">foul</span>, or lands out of the end zone due to an uncontested force-out foul (<a href="https://usaultimate.org/rules/#17.I.4.b.4">17.I.4.b.4</a>), that player is awarded a goal.
                         </li>
-                    </ol>
+                    </ul>
                 </li>
 
-                <li><a id="12.B"></a>If after receiving a pass outside the end zone, a player comes to a stop contacting the end zone without a pivot on the central zone, that player must carry the disc back to, and put it into play at, the closest spot on the goal line.</li>
-                <li><a id="12.C"></a>If a player scores according to <a href="https://usaultimate.org/rules/#12.A">12.A</a>, but then unknowingly throws another pass, a goal is awarded to that player, regardless of the outcome of the pass. However, if it is unclear if the player scored according to <a href="https://usaultimate.org/rules/#12.A">12.A</a> (i.e., there is no agreement on the player who had <span class="tooltip" title="The most complete view available by a player that includes the relative positions of the disc, ground, players, and line markers involved in a play. On an unlined field, this may require sighting from one field marker to another.">best perspective</span>, and there are opposing viewpoints on the play), the result of the pass stands.</li>
+                <li><a id="12.B">12.B.</a> If after receiving a pass outside the end zone, a player comes to a stop contacting the end zone without a pivot on the central zone, that player must carry the disc back to, and put it into play at, the closest spot on the goal line.</li>
+                <li><a id="12.C">12.C.</a> If a player scores according to <a href="https://usaultimate.org/rules/#12.A">12.A</a>, but then unknowingly throws another pass, a goal is awarded to that player, regardless of the outcome of the pass. However, if it is unclear if the player scored according to <a href="https://usaultimate.org/rules/#12.A">12.A</a> (i.e., there is no agreement on the player who had <span class="tooltip" title="The most complete view available by a player that includes the relative positions of the disc, ground, players, and line markers involved in a play. On an unlined field, this may require sighting from one field marker to another.">best perspective</span>, and there are opposing viewpoints on the play), the result of the pass stands.</li>
                 <li>
-                    <a id="12.D"></a>If a player catches the disc and believes a goal has been scored the player may call “goal” and play stops.
+                    <a id="12.D">12.D.</a> If a player catches the disc and believes a goal has been scored the player may call “goal” and play stops.
                     <span class="annotation">[[Under 12.A, scoring a goal includes surviving all ground contact related to the catch. Thus, “goal” may not be called if the player did not maintain possession through all ground contact related to the catch, nor may “goal” be called prior to completion of all ground contact related to the catch.]]</span>
                     Best practice is to announce “goal” and raise both hands vertically above the head. After a contested or retracted goal call, play must restart with a check and the call is deemed to have been made when the pass was caught.
                     <span class="annotation">[[Accordingly, the stall count will resume at 1 (<a href="https://usaultimate.org/rules/#15.5">15.5</a>, <a href="https://usaultimate.org/rules/#15.5.a.5">15.5.a.5</a>). When repositioning, all players should return to where they were when the pass was caught (<a href="https://usaultimate.org/rules/#17.C.6.a">17.C.6.a</a>).]]</span>
                     <span class="annotation">[[In an observed game, in/out of the end zone and “goal” are active observer calls, and player calls are ignored. Therefore, in an observed game, a player's “goal” call does not stop play.]]</span>
                     <span class="annotation">[[If it is ever unclear whether “goal” was called, play continues and 12.C applies to subsequent throws (undisputed goals stand, turnovers stand on disputed goals). Unlike under WFDF rules, celebration or other actions following a suspected goal do not substitute for a “goal” call under this rule.]]</span>
                 </li>
-                <li><a id="12.A"></a>The act of scoring a goal is subject to rule <a href="https://usaultimate.org/rules/#3.J.2">3.J.2</a>.</li>
-            </ol>
+                <li><a id="12.A">12.A.</a> The act of scoring a goal is subject to rule <a href="https://usaultimate.org/rules/#3.J.2">3.J.2</a>.</li>
+            </ul>
         </li>
 
         <li>
-            <a id="13"></a>Turnovers
-            <ol>
+            <a id="13">13.</a> Turnovers
+            <ul>
                 <li>
-                    <a id="13.A"></a>A turnover results when:
-                    <ol>
-                        <li><a id="13.A.1"></a>a pass is incomplete;</li>
-                        <li><a id="13.A.2"></a>a disc contacts the ground while not in possession of a player other than as a result of a <span class="tooltip" title="The throw from one team to the other that starts play at the beginning of a half or after a goal. It is not a legal pass for scoring and has many special provisions (Section 9.B). The player on the pulling team who possesses the disc and signals readiness is the puller.">pull</span>; or</li>
-                        <li><a id="13.A.3"></a>a disc becomes out-of-bounds other than as a result of a <span class="tooltip" title="The throw from one team to the other that starts play at the beginning of a half or after a goal. It is not a legal pass for scoring and has many special provisions (Section 9.B). The player on the pulling team who possesses the disc and signals readiness is the puller.">pull</span>.</li>
-                    </ol>
+                    <a id="13.A">13.A.</a> A turnover results when:
+                    <ul>
+                        <li><a id="13.A.1">13.A.1.</a> a pass is incomplete;</li>
+                        <li><a id="13.A.2">13.A.2.</a> a disc contacts the ground while not in possession of a player other than as a result of a <span class="tooltip" title="The throw from one team to the other that starts play at the beginning of a half or after a goal. It is not a legal pass for scoring and has many special provisions (Section 9.B). The player on the pulling team who possesses the disc and signals readiness is the puller.">pull</span>; or</li>
+                        <li><a id="13.A.3">13.A.3.</a> a disc becomes out-of-bounds other than as a result of a <span class="tooltip" title="The throw from one team to the other that starts play at the beginning of a half or after a goal. It is not a legal pass for scoring and has many special provisions (Section 9.B). The player on the pulling team who possesses the disc and signals readiness is the puller.">pull</span>.</li>
+                    </ul>
                 </li>
 
                 <li>
-                    <a id="13.B"></a>If the thrower accidentally drops a
+                    <a id="13.B">13.B.</a> If the thrower accidentally drops a
                     <span class="tooltip" title="A disc is live when players are allowed to move and the disc is subject to a turnover, but the thrower cannot make a legal pass (e.g., walking the disc to the spot where it is to be put into play). For a live disc to be put into play, the thrower must (1) establish a pivot at the appropriate spot on the field, and (2) touch the disc to the ground (14.B).">live</span>
                     disc or a disc
                     <span class="tooltip" title="A disc is in play when players are allowed to move and play may proceed without the defense&#39;s acknowledgment. An in-bounds disc in the central zone is in play. The disc is subject to a turnover. If no player has possession of a disc in play, any offensive player may become the thrower by taking possession of the disc (14.A). Once a player has possession of the disc, they must establish a pivot at the spot of the disc 14.A.2) prior to attempting a pass (17.K).">in play</span>
@@ -1159,7 +1164,7 @@
                     If the thrower regains possession of an accidentally dropped disc before it contacts the ground and after another player touches it, it is considered a new possession.
                 </li>
                 <li>
-                    <a id="13.C"></a>A pass is intercepted if a
+                    <a id="13.C">13.C.</a> A pass is intercepted if a
                     <span class="tooltip" title="A player whose team is not in possession of the disc. A defensive player may not pick up a live disc or a disc in play or call for a pass from the thrower.">defensive player</span>
                     obtains
                     <span class="tooltip" title="Sustained contact with, and control of, a non-spinning disc.">possession</span>
@@ -1169,207 +1174,207 @@
                     <span class="annotation">[[i.e., this is not a “double-turnover” – the defender's team still gains possession.]]</span>
                 </li>
                 <li>
-                    <a id="13.D"></a>The following actions result in a turnover and a <span class="tooltip" title="Any halting of play due to a call, discussion, or timeout that requires a check or self-check to restart play. The term play stops means a stoppage of play occurs.">stoppage of play</span>:
-                    <ol>
+                    <a id="13.D">13.D.</a> The following actions result in a turnover and a <span class="tooltip" title="Any halting of play due to a call, discussion, or timeout that requires a check or self-check to restart play. The term play stops means a stoppage of play occurs.">stoppage of play</span>:
+                    <ul>
                         <li>
-                            <a id="13.D.1"></a>The
+                            <a id="13.D.1">13.D.1.</a> The
                             <span class="tooltip" title="The defensive player within ten feet of the thrower&#39;s pivot or of the thrower if no pivot has been established. If the disc is not in a player&#39;s possession, a defensive player within ten feet of a spot on the field where the disc is to be put into play is considered the marker.">marker's</span>
                             count reaches ten before the throw is released (<a href="https://usaultimate.org/rules/#15.A.3">15.A.3</a>).
                         </li>
-                        <li><a id="13.D.2"></a>The thrower hands the disc to another player.</li>
-                        <li><a id="13.D.3"></a>The thrower catches a legally thrown disc. However, it is not a turnover if another player touches the disc during its flight unless the thrower intentionally deflected the disc off another player.</li>
+                        <li><a id="13.D.2">13.D.2.</a> The thrower hands the disc to another player.</li>
+                        <li><a id="13.D.3">13.D.3.</a> The thrower catches a legally thrown disc. However, it is not a turnover if another player touches the disc during its flight unless the thrower intentionally deflected the disc off another player.</li>
                         <li>
-                            <a id="13.D.4"></a>An
+                            <a id="13.D.4">13.D.4.</a> An
                             <span class="tooltip" title="A player whose team is in possession of the disc.">offensive player</span>
                             intentionally assists a teammate's movement to catch a pass.
                             <span class="annotation">[[The official interpretation of this rule is that a player is prohibited from intentionally pushing off of a teammate to jump higher]]</span>
                             If a defender intentionally assists a teammate's movement to block or intercept a pass, the intended receiver is awarded possession at the spot on the playing field nearest the location the intended receiver occupied at the time of the infraction. If the intended receiver was in the end zone, <a href="https://usaultimate.org/rules/#11.B">11.B</a> and <a href="https://usaultimate.org/rules/#11.C">11.C</a> apply.
                         </li>
                         <li>
-                            <a id="13.D.5"></a>An
+                            <a id="13.D.5">13.D.5.</a> An
                             <span class="tooltip" title="A player whose team is in possession of the disc.">offensive player</span>
                             uses an item of equipment to assist in catching a pass (e.g., throwing a hat or shirt at the disc). If a defender uses an item of equipment to assist in blocking or intercepting a pass, the intended receiver is awarded possession at the spot on the playing field nearest the location the intended receiver occupied at the time of the infraction. If the intended receiver was in the end zone,
                             <a href="https://usaultimate.org/rules/#11.B">11.B</a> and <a href="https://usaultimate.org/rules/#11.C">11.C</a> apply.
                             <span class="annotation">[[Tacky gloves are legal and do not result in a turnover under this rule.]]</span>
                         </li>
-                    </ol>
+                    </ul>
                 </li>
-            </ol>
+            </ul>
         </li>
 
         <li>
-            <a id="14"></a>The Thrower
-            <ol>
+            <a id="14">14.</a> The Thrower
+            <ul>
                 <li>
-                    <a id="14.A"></a>If the disc is on the ground, whether in- or out-of-bounds, any member of the team becoming offense may take possession of it.
-                    <ol>
+                    <a id="14.A">14.A.</a> If the disc is on the ground, whether in- or out-of-bounds, any member of the team becoming offense may take possession of it.
+                    <ul>
                         <li>
-                            <a id="14.A.1"></a>If an
+                            <a id="14.A.1">14.A.1.</a> If an
                             <span class="tooltip" title="A player whose team is in possession of the disc.">offensive player</span>
                             picks up a live or in play disc, that player must put it into play.
                         </li>
                         <li>
-                            <a id="14.A.2"></a>If
+                            <a id="14.A.2">14.A.2.</a> If
                             <span class="tooltip" title="Sustained contact with, and control of, a non-spinning disc.">possession</span>
                             is gained at the spot where the disc is
                             <span class="tooltip" title="A disc is in play when players are allowed to move and play may proceed without the defense&#39;s acknowledgment. An in-bounds disc in the central zone is in play. The disc is subject to a turnover. If no player has possession of a disc in play, any offensive player may become the thrower by taking possession of the disc (14.A). Once a player has possession of the disc, they must establish a pivot at the spot of the disc 14.A.2) prior to attempting a pass (17.K).">in play</span>, the thrower must establish a pivot at the spot of the disc.
                             <span class="annotation">[[The thrower should pick up the disc and place the pivot at the spot of the disc.]]</span>
                         </li>
                         <li>
-                            <a id="14.A.3"></a>If an in-bounds disc comes to rest on the central zone, a member of the team becoming offense must pick up the disc and establish a pivot within ten seconds after it comes to rest.
+                            <a id="14.A.3">14.A.3.</a> If an in-bounds disc comes to rest on the central zone, a member of the team becoming offense must pick up the disc and establish a pivot within ten seconds after it comes to rest.
                             <span class="annotation">[[The 70 x 40 yard box]]</span>
                             After ten seconds elapse, a
                             <span class="tooltip" title="A player whose team is not in possession of the disc. A defensive player may not pick up a live disc or a disc in play or call for a pass from the thrower.">defensive player</span>
                             within ten feet of the disc may announce “disc in,” and then initiate and continue the stall count, but only if a defensive player has given audible warnings of ten and five seconds (the pre-stall).
                         </li>
                         <li>
-                            <a id="14.A.4"></a>If the disc is out-of-bounds (<a href="https://usaultimate.org/rules/#10.E">10.E</a>) or comes to rest in the end zone, a member of the team becoming offense must put the disc into play within twenty seconds after it comes to rest.
+                            <a id="14.A.4">14.A.4.</a> If the disc is out-of-bounds (<a href="https://usaultimate.org/rules/#10.E">10.E</a>) or comes to rest in the end zone, a member of the team becoming offense must put the disc into play within twenty seconds after it comes to rest.
                             <span class="annotation">[[For an out-of bounds disc that has come to rest on the central zone, the team becoming offense will have twenty seconds to put it into play.]]</span>
-                            <ol>
-                                <li><a id="14.A.4.a"></a>If the disc is out of bounds and not reasonably retrievable quickly, a replacement disc may be introduced without a stoppage of play. The player retrieving the disc must first confirm with a player on the opposing team that the new disc is acceptable. The player putting the new disc into play must then raise the replacement disc above their head and announce “new disc” before putting the disc into play according to <a href="https://usaultimate.org/rules/#10.H">10.H</a>.</li>
+                            <ul>
+                                <li><a id="14.A.4.a">14.A.4.a.</a> If the disc is out of bounds and not reasonably retrievable quickly, a replacement disc may be introduced without a stoppage of play. The player retrieving the disc must first confirm with a player on the opposing team that the new disc is acceptable. The player putting the new disc into play must then raise the replacement disc above their head and announce “new disc” before putting the disc into play according to <a href="https://usaultimate.org/rules/#10.H">10.H</a>.</li>
                                 <li>
-                                    <a id="14.A.4.b"></a>If the disc is in the end zone, after twenty seconds elapse, a
+                                    <a id="14.A.4.b">14.A.4.b.</a> If the disc is in the end zone, after twenty seconds elapse, a
                                     <span class="tooltip" title="A player whose team is not in possession of the disc. A defensive player may not pick up a live disc or a disc in play or call for a pass from the thrower.">defensive player</span>
                                     within 10 feet of the disc may announce “disc in,” and then initiate and continue the stall count, but only if a defensive player has given audible warnings of twenty, ten and five seconds (the pre-stall).
                                 </li>
                                 <li>
-                                    <a id="14.A.4.c"></a>If the disc is out-of-bounds, after twenty seconds elapse, a
+                                    <a id="14.A.4.c">14.A.4.c.</a> If the disc is out-of-bounds, after twenty seconds elapse, a
                                     <span class="tooltip" title="A player whose team is not in possession of the disc. A defensive player may not pick up a live disc or a disc in play or call for a pass from the thrower.">defensive player</span>
                                     within ten feet of the spot the disc is to be put into play may announce “disc in,” and then initiate and continue the stall count, but only if a defensive player has given audible warnings of twenty, ten and five seconds (the pre-stall).
                                 </li>
                                 <li>
-                                    <a id="14.A.4.d"></a>Non-playing members of the team on offense may assist in retrieving
+                                    <a id="14.A.4.d">14.A.4.d.</a> Non-playing members of the team on offense may assist in retrieving
                                     <span class="tooltip" title="A disc is live when players are allowed to move and the disc is subject to a turnover, but the thrower cannot make a legal pass (e.g., walking the disc to the spot where it is to be put into play). For a live disc to be put into play, the thrower must (1) establish a pivot at the appropriate spot on the field, and (2) touch the disc to the ground (14.B).">live</span>
                                     discs outside the player and team lines (or, if no such lines exist, live discs in the out-of-bounds area). Such players cannot cause a turnover. Once a player obtains
                                     <span class="tooltip" title="Sustained contact with, and control of, a non-spinning disc.">possession</span>
                                     of the disc, they must carry the disc to a spot outside the team line (or, if no such line exists, at least three yards away from the playing field) before carrying it to the spot where it is to be put into play.
                                 </li>
-                            </ol>
+                            </ul>
                         </li>
 
                         <li>
-                            <a id="14.A.5"></a>If an
+                            <a id="14.A.5">14.A.5.</a> If an
                             <span class="tooltip" title="A player whose team is in possession of the disc.">offensive player</span>
                             unnecessarily delays putting the disc into play in violation of rule <a href="https://usaultimate.org/rules/#20.B">20.B</a>, a defender within ten feet of the spot the disc is to be put into play may issue a delay of game warning instead of calling a violation, by announcing “delay of game” and counting down from three to zero at intervals of at least one second to provide an opportunity for the offensive player to react to the warning. Play then continues as follows:
-                            <ol>
+                            <ul>
                                 <li>
-                                    <a id="14.A.5.a"></a>If the behavior in violation of rule <a href="https://usaultimate.org/rules/#20.B">20.B</a> is stopped before the full utterance of the word “zero,” the
+                                    <a id="14.A.5.a">14.A.5.a.</a> If the behavior in violation of rule <a href="https://usaultimate.org/rules/#20.B">20.B</a> is stopped before the full utterance of the word “zero,” the
                                     <span class="tooltip" title="The defensive player within ten feet of the thrower&#39;s pivot or of the thrower if no pivot has been established. If the disc is not in a player&#39;s possession, a defensive player within ten feet of a spot on the field where the disc is to be put into play is considered the marker.">marker</span>
                                     stops the count-down and may only initiate the stall count as usual, according to
                                     <a href="https://usaultimate.org/rules/#15.A.2">15.A.2</a>.
                                     <span class="annotation">[[An example of “stopping” behavior in violation of rule 20.B is to begin moving toward the disc at walking pace. Another example would be to run downfield, leaving the disc for someone else to pick up. However, if a player is taking more time than reasonably necessary to put the disc into play by standing back from the disc, wandering around near the disc, or standing over the disc, continuing such behavior during the three-second countdown will allow a marker to initiate the stall count under <a href="https://usaultimate.org/rules/#14.A.5">14.A.5</a>.]]</span>
                                 </li>
                                 <li>
-                                    <a id="14.A.5.b"></a>If the behavior in violation of rule <a href="https://usaultimate.org/rules/#20.B">20.B</a> is not stopped before the full utterance of the word “zero,” the
+                                    <a id="14.A.5.b">14.A.5.b.</a> If the behavior in violation of rule <a href="https://usaultimate.org/rules/#20.B">20.B</a> is not stopped before the full utterance of the word “zero,” the
                                     <span class="tooltip" title="The defensive player within ten feet of the thrower&#39;s pivot or of the thrower if no pivot has been established. If the disc is not in a player&#39;s possession, a defensive player within ten feet of a spot on the field where the disc is to be put into play is considered the marker.">marker</span>
                                     may then initiate or continue a stall count, regardless of any subsequent actions by the offense, by announcing “disc in” and then initiating the stall count.
                                 </li>
-                            </ol>
+                            </ul>
                         </li>
-                    </ol>
+                    </ul>
                 </li>
 
                 <li>
-                    <a id="14.B"></a>For a
+                    <a id="14.B">14.B.</a> For a
                     <span class="tooltip" title="A disc is live when players are allowed to move and the disc is subject to a turnover, but the thrower cannot make a legal pass (e.g., walking the disc to the spot where it is to be put into play). For a live disc to be put into play, the thrower must (1) establish a pivot at the appropriate spot on the field, and (2) touch the disc to the ground (14.B).">live</span>
                     disc to be put into play, the thrower must establish a pivot at the appropriate spot on the field, and touch the disc to the ground.
                 </li>
-            </ol>
+            </ul>
         </li>
 
         <li>
-            <a id="15"></a>The Marker
-            <ol>
+            <a id="15">15.</a> The Marker
+            <ul>
                 <li>
-                    <a id="15.A"></a>Stalling: The period of time within which a thrower must release a throw may be timed by the stall count.
-                    <ol>
+                    <a id="15.A">15.A.</a> Stalling: The period of time within which a thrower must release a throw may be timed by the stall count.
+                    <ul>
                         <li>
-                            <a id="15.A.1"></a>The stall count consists of announcing “stalling” and counting from one to ten loudly enough for the thrower to hear.
-                            <ol>
+                            <a id="15.A.1">15.A.1.</a> The stall count consists of announcing “stalling” and counting from one to ten loudly enough for the thrower to hear.
+                            <ul>
                                 <li>
-                                    <a id="15.A.1.a"></a>The interval between the first utterance of each number in the stall count must be at least one second.
+                                    <a id="15.A.1.a">15.A.1.a.</a> The interval between the first utterance of each number in the stall count must be at least one second.
                                     <span class="annotation">[[Thus, a legal count from one to ten will take a minimum of 9 seconds. It is legal count at intervals greater than one second between numbers]]</span>
                                 </li>
                                 <li>
-                                    <a id="15.A.1.b"></a>All stall counts initiated, reinitiated or resumed after a
+                                    <a id="15.A.1.b">15.A.1.b.</a> All stall counts initiated, reinitiated or resumed after a
                                     <span class="tooltip" title="Any halting of play due to a call, discussion, or timeout that requires a check or self-check to restart play. The term play stops means a stoppage of play occurs.">stoppage of play</span>
                                     must start with the word “stalling.”
                                 </li>
-                                <li><a id="15.A.1.c"></a>If the count resets to one during a <span class="tooltip" title="Any halting of play due to a call, discussion, or timeout that requires a check or self-check to restart play. The term play stops means a stoppage of play occurs.">stoppage of play</span>, it is considered a new count.</li>
-                            </ol>
+                                <li><a id="15.A.1.c">15.A.1.c.</a> If the count resets to one during a <span class="tooltip" title="Any halting of play due to a call, discussion, or timeout that requires a check or self-check to restart play. The term play stops means a stoppage of play occurs.">stoppage of play</span>, it is considered a new count.</li>
+                            </ul>
                         </li>
 
                         <li>
-                            <a id="15.A.2"></a>Only the
+                            <a id="15.A.2">15.A.2.</a> Only the
                             <span class="tooltip" title="The defensive player within ten feet of the thrower&#39;s pivot or of the thrower if no pivot has been established. If the disc is not in a player&#39;s possession, a defensive player within ten feet of a spot on the field where the disc is to be put into play is considered the marker.">marker</span>
                             (<a href="https://usaultimate.org/rules/#3.Q.6">3.Q.6</a>) may initiate or continue a stall count, and may do so anytime a thrower has possession of a disc that is
                             <span class="tooltip" title="A disc is live when players are allowed to move and the disc is subject to a turnover, but the thrower cannot make a legal pass (e.g., walking the disc to the spot where it is to be put into play). For a live disc to be put into play, the thrower must (1) establish a pivot at the appropriate spot on the field, and (2) touch the disc to the ground (14.B).">live</span>
                             or
                             <span class="tooltip" title="A disc is in play when players are allowed to move and play may proceed without the defense&#39;s acknowledgment. An in-bounds disc in the central zone is in play. The disc is subject to a turnover. If no player has possession of a disc in play, any offensive player may become the thrower by taking possession of the disc (14.A). Once a player has possession of the disc, they must establish a pivot at the spot of the disc 14.A.2) prior to attempting a pass (17.K).">in play</span>.
-                            <ol>
-                                <li><a id="15.A.2.a"></a>Additionally, the marker may initiate or continue a stall count (even before a thrower gains possession) if delay of game or pre-stall rules (<a href="https://usaultimate.org/rules/#14.A.3">14.A.3</a>, <a href="https://usaultimate.org/rules/#14.A.4">14.A.4</a>, <a href="https://usaultimate.org/rules/#14.A.5">14.A.5</a>, or <a href="https://usaultimate.org/rules/#7.B.4.d">7.B.4.d</a>) apply and have been satisfied.</li>
+                            <ul>
+                                <li><a id="15.A.2.a">15.A.2.a.</a> Additionally, the marker may initiate or continue a stall count (even before a thrower gains possession) if delay of game or pre-stall rules (<a href="https://usaultimate.org/rules/#14.A.3">14.A.3</a>, <a href="https://usaultimate.org/rules/#14.A.4">14.A.4</a>, <a href="https://usaultimate.org/rules/#14.A.5">14.A.5</a>, or <a href="https://usaultimate.org/rules/#7.B.4.d">7.B.4.d</a>) apply and have been satisfied.</li>
                                 <li>
-                                    <a id="15.A.2.b"></a>However, unless <a href="https://usaultimate.org/rules/#15.A.2.a">15.A.2.a</a> applies, the stall count may not be initiated or resumed before a pivot is established:
-                                    <ol>
+                                    <a id="15.A.2.b">15.A.2.b.</a> However, unless <a href="https://usaultimate.org/rules/#15.A.2.a">15.A.2.a</a> applies, the stall count may not be initiated or resumed before a pivot is established:
+                                    <ul>
                                         <li>
-                                            <a id="15.A.2.b.1">directly after a turnover,</a>
+                                            <a id="15.A.2.b.1">15.A.2.b.1.dire ctly after a turnover,</a>
                                         </li>
                                         <li>
-                                            <a id="15.A.2.b.2">when putting the pull into play, and</a>
+                                            <a id="15.A.2.b.2">15.A.2.b.2.when  putting the pull into play, and</a>
                                         </li>
                                         <li>
-                                            <a id="15.A.2.b.3">after a travel is called and no pass has been attempted.</a>
+                                            <a id="15.A.2.b.3">15.A.2.b.3.afte r a travel is called and no pass has been attempted.</a>
                                         </li>
-                                    </ol>
+                                    </ul>
                                 </li>
-                            </ol>
+                            </ul>
                         </li>
 
                         <li>
-                            <a id="15.A.3"></a>If the thrower has not released the disc at the first utterance of the word “ten,” it is a turnover. The
+                            <a id="15.A.3">15.A.3.</a> If the thrower has not released the disc at the first utterance of the word “ten,” it is a turnover. The
                             <span class="tooltip" title="The defensive player within ten feet of the thrower&#39;s pivot or of the thrower if no pivot has been established. If the disc is not in a player&#39;s possession, a defensive player within ten feet of a spot on the field where the disc is to be put into play is considered the marker.">marker</span>
                             loudly announces “stall” and play stops. If the disc is thrown, play continues until the outcome of that pass is determined. A stall is not a violation and the Continuation Rule (<a href="https://usaultimate.org/rules/#17.C">17.C</a>) does not apply.
-                            <ol>
-                                <li><a id="15.A.3.a"></a>If the stall is uncontested, the disc is returned to the thrower at the place of the stall. The thrower then places the disc on the ground and loudly announces “3-2-1 disc in” and the disc is <span class="tooltip" title="A disc is in play when players are allowed to move and play may proceed without the defense&#39;s acknowledgment. An in-bounds disc in the central zone is in play. The disc is subject to a turnover. If no player has possession of a disc in play, any offensive player may become the thrower by taking possession of the disc (14.A). Once a player has possession of the disc, they must establish a pivot at the spot of the disc 14.A.2) prior to attempting a pass (17.K).">in play</span>.</li>
+                            <ul>
+                                <li><a id="15.A.3.a">15.A.3.a.</a> If the stall is uncontested, the disc is returned to the thrower at the place of the stall. The thrower then places the disc on the ground and loudly announces “3-2-1 disc in” and the disc is <span class="tooltip" title="A disc is in play when players are allowed to move and play may proceed without the defense&#39;s acknowledgment. An in-bounds disc in the central zone is in play. The disc is subject to a turnover. If no player has possession of a disc in play, any offensive player may become the thrower by taking possession of the disc (14.A). Once a player has possession of the disc, they must establish a pivot at the spot of the disc 14.A.2) prior to attempting a pass (17.K).">in play</span>.</li>
                                 <li>
-                                    <a id="15.A.3.b"></a>The thrower may contest a stall call in the belief that the disc was released before the first utterance of the word “ten” or if the
+                                    <a id="15.A.3.b">15.A.3.b.</a> The thrower may contest a stall call in the belief that the disc was released before the first utterance of the word “ten” or if the
                                     <span class="tooltip" title="The defensive player within ten feet of the thrower&#39;s pivot or of the thrower if no pivot has been established. If the disc is not in a player&#39;s possession, a defensive player within ten feet of a spot on the field where the disc is to be put into play is considered the marker.">marker</span>
                                     committed a fast count such that the thrower did not have a reasonable opportunity to call “fast count” before the first utterance of the word “ten.” If a stall is contested:
-                                    <ol>
+                                    <ul>
                                         <li>
-                                            <a id="15.A.3.b.1"></a>If the pass was complete or
+                                            <a id="15.A.3.b.1">15.A.3.b.1.</a> If the pass was complete or
                                             <a href="https://usaultimate.org/rules/#15.B.5.b">15.B.5.b</a>
                                             applies, play stops, players return to their positions at the time of the throw, and possession reverts to the thrower. After a check, the
                                             <span class="tooltip" title="The defensive player within ten feet of the thrower&#39;s pivot or of the thrower if no pivot has been established. If the disc is not in a player&#39;s possession, a defensive player within ten feet of a spot on the field where the disc is to be put into play is considered the marker.">marker</span>
                                             resumes the stall count according to
                                             <a href="https://usaultimate.org/rules/#15.A.5.b.3">15.A.5.b.3</a>.
                                         </li>
-                                        <li><a id="15.A.3.b.2"></a>If the pass was incomplete, it is a turnover; play stops and resumes with a check.</li>
+                                        <li><a id="15.A.3.b.2">15.A.3.b.2.</a> If the pass was incomplete, it is a turnover; play stops and resumes with a check.</li>
                                         <li>
-                                            <a id="15.A.3.b.3"></a>If a stall call is retracted and the thrower attempted a pass, the outcome of the pass stands and play restarts with a check.
+                                            <a id="15.A.3.b.3">15.A.3.b.3.</a> If a stall call is retracted and the thrower attempted a pass, the outcome of the pass stands and play restarts with a check.
                                             <span class="annotation"
                                                 >[[A
                                                 <span class="tooltip" title="The defensive player within ten feet of the thrower&#39;s pivot or of the thrower if no pivot has been established. If the disc is not in a player&#39;s possession, a defensive player within ten feet of a spot on the field where the disc is to be put into play is considered the marker.">marker</span>
                                                 should not automatically call “stall” because they got to the count of ten. They should be certain that the disc was not yet released and that their count wasn't fast.]]</span
                                             >
                                         </li>
-                                    </ol>
+                                    </ul>
                                 </li>
-                            </ol>
+                            </ul>
                         </li>
 
                         <li>
-                            <a id="15.A.4"></a>If the defense switches <span class="tooltip" title="The defensive player within ten feet of the thrower&#39;s pivot or of the thrower if no pivot has been established. If the disc is not in a player&#39;s possession, a defensive player within ten feet of a spot on the field where the disc is to be put into play is considered the marker.">markers</span>, the new marker must reinitiate the stall count.
+                            <a id="15.A.4">15.A.4.</a> If the defense switches <span class="tooltip" title="The defensive player within ten feet of the thrower&#39;s pivot or of the thrower if no pivot has been established. If the disc is not in a player&#39;s possession, a defensive player within ten feet of a spot on the field where the disc is to be put into play is considered the marker.">markers</span>, the new marker must reinitiate the stall count.
                             <span class="annotation">[[Reinitiate the stall count means to start over (“stalling one…”).]]</span>
                             A marker leaving the ten foot radius and returning is considered a new marker.
                         </li>
                         <li>
-                            <a id="15.A.5"></a>If a stall count is interrupted by a call, the thrower and
+                            <a id="15.A.5">15.A.5.</a> If a stall count is interrupted by a call, the thrower and
                             <span class="tooltip" title="The defensive player within ten feet of the thrower&#39;s pivot or of the thrower if no pivot has been established. If the disc is not in a player&#39;s possession, a defensive player within ten feet of a spot on the field where the disc is to be put into play is considered the marker.">marker</span>
                             are responsible for agreeing on the correct count before the check. The count reached is the last number fully uttered by the marker before the call. The count is resumed with the word “stalling” followed by the number listed below:
-                            <ol>
+                            <ul>
                                 <li>
-                                    <a id="15.A.5.a"></a>General Rules:
+                                    <a id="15.A.5.a">15.A.5.a.</a> General Rules:
                                     <table class="normal rules">
                                         <tbody>
                                             <tr>
@@ -1405,7 +1410,7 @@
                                 </li>
 
                                 <li>
-                                    <a id="15.A.5.b"></a>Specific Rules:
+                                    <a id="15.A.5.b">15.A.5.b.</a> Specific Rules:
                                     <table class="normal rules">
                                         <tbody>
                                             <tr>
@@ -1439,40 +1444,40 @@
                                         </tbody>
                                     </table>
                                 </li>
-                            </ol>
+                            </ul>
                         </li>
-                    </ol>
+                    </ul>
                 </li>
 
                 <li>
-                    <a id="15.B"></a>Marking Violations:
-                    <ol>
-                        <li><a id="15.B.1"></a>Marking violations are infractions committed against the thrower by the <span class="tooltip" title="The defensive player within ten feet of the thrower&#39;s pivot or of the thrower if no pivot has been established. If the disc is not in a player&#39;s possession, a defensive player within ten feet of a spot on the field where the disc is to be put into play is considered the marker.">marker</span> or another defensive player close to the thrower, as outlined below.</li>
-                        <li><a id="15.B.2"></a>Only the thrower may call a marking violation, and to do so must call out the name of the specific marking violation.</li>
+                    <a id="15.B">15.B.</a> Marking Violations:
+                    <ul>
+                        <li><a id="15.B.1">15.B.1.</a> Marking violations are infractions committed against the thrower by the <span class="tooltip" title="The defensive player within ten feet of the thrower&#39;s pivot or of the thrower if no pivot has been established. If the disc is not in a player&#39;s possession, a defensive player within ten feet of a spot on the field where the disc is to be put into play is considered the marker.">marker</span> or another defensive player close to the thrower, as outlined below.</li>
+                        <li><a id="15.B.2">15.B.2.</a> Only the thrower may call a marking violation, and to do so must call out the name of the specific marking violation.</li>
                         <li>
-                            <a id="15.B.3"></a>When a marking violation is called, play does not stop. The violation must be corrected before the <span class="tooltip" title="The defensive player within ten feet of the thrower&#39;s pivot or of the thrower if no pivot has been established. If the disc is not in a player&#39;s possession, a defensive player within ten feet of a spot on the field where the disc is to be put into play is considered the marker.">marker</span> can resume the stall count with the number last uttered before the call minus one (e.g., “stalling one...two...three…” “fast count” ”...two...three…”). <span class="annotation">[[When a marking violation is called, the marker should immediately stop counting. The defense should then correct the violation and the marker can then resume the count at the appropriate number.]]</span> If the marker resumes the stall count before the defense corrects a marking violation, it is another instance of the original marking
+                            <a id="15.B.3">15.B.3.</a> When a marking violation is called, play does not stop. The violation must be corrected before the <span class="tooltip" title="The defensive player within ten feet of the thrower&#39;s pivot or of the thrower if no pivot has been established. If the disc is not in a player&#39;s possession, a defensive player within ten feet of a spot on the field where the disc is to be put into play is considered the marker.">marker</span> can resume the stall count with the number last uttered before the call minus one (e.g., “stalling one...two...three…” “fast count” ”...two...three…”). <span class="annotation">[[When a marking violation is called, the marker should immediately stop counting. The defense should then correct the violation and the marker can then resume the count at the appropriate number.]]</span> If the marker resumes the stall count before the defense corrects a marking violation, it is another instance of the original marking
                             violation, which may be called by the thrower.
                         </li>
                         <li>
-                            <a id="15.B.4">If the defense commits a marking violation after being called for a marking violation during the same stall count (<a href="https://usaultimate.org/rules/#15.A.1">15.A.1</a>) but before the thrower is in the act of throwing, the thrower may choose to either call another marking violation or to treat the marking violation as a general defensive violation (<a href="https://usaultimate.org/rules/#17">17</a>). To treat it as a general violation, the thrower must call “violation.”</a>
+                            <a id="15.B.4">15.B.4.</a> If the defense commits a marking violation after being called for a marking violation during the same stall count (<a href="https://usaultimate.org/rules/#15.A.1">15.A.1</a>) but before the thrower is in the act of throwing, the thrower may choose to either call another marking violation or to treat the marking violation as a general defensive violation (<a href="https://usaultimate.org/rules/#17">17</a>). To treat it as a general violation, the thrower must call “violation.”</a>
                         </li>
                         <li>
-                            <a id="15.B.5">Marking violations are: Fast count, double team, disc space, straddle, wrapping, and vision blocking.</a>
+                            <a id="15.B.5">15.B.5.</a> Marking violations are: Fast count, double team, disc space, straddle, wrapping, and vision blocking.</a>
                         </li>
                         <li>
-                            <a id="15.B.6">Fast count:</a>
-                            <ol>
+                            <a id="15.B.6">15.B.6.</a> Fast count:
+                            <ul>
                                 <li>
-                                    <a id="15.B.6.a"></a>If the
+                                    <a id="15.B.6.a">15.B.6.a.</a> If the
                                     <span class="tooltip" title="The defensive player within ten feet of the thrower&#39;s pivot or of the thrower if no pivot has been established. If the disc is not in a player&#39;s possession, a defensive player within ten feet of a spot on the field where the disc is to be put into play is considered the marker.">marker</span>
                                     does not say “stalling” to initiate or resume a stall count, counts at intervals of less than one second, or skips a number in the count, it is a fast count.
                                 </li>
-                                <li><a id="15.B.6.b"></a>If a fast count occurs in such a manner that the thrower does not have a reasonable opportunity to call fast count before the first utterance of the word ten, the play is treated as a contested stall (<a href="https://usaultimate.org/rules/#15.A.3.b">15.A.3.b</a>).</li>
-                                <li><a id="15.B.6.c"></a>If this (<a href="https://usaultimate.org/rules/#15.B.6.b">15.B.6.b</a>) occurs in the same possession following a contested stall (either due to <a href="https://usaultimate.org/rules/#15.B.6.a">15.B.6.a</a> or <a href="https://usaultimate.org/rules/#15.A.3.b">15.A.3.b</a>), the stall count resumes at six.</li>
-                            </ol>
+                                <li><a id="15.B.6.b">15.B.6.b.</a> If a fast count occurs in such a manner that the thrower does not have a reasonable opportunity to call fast count before the first utterance of the word ten, the play is treated as a contested stall (<a href="https://usaultimate.org/rules/#15.A.3.b">15.A.3.b</a>).</li>
+                                <li><a id="15.B.6.c">15.B.6.c.</a> If this (<a href="https://usaultimate.org/rules/#15.B.6.b">15.B.6.b</a>) occurs in the same possession following a contested stall (either due to <a href="https://usaultimate.org/rules/#15.B.6.a">15.B.6.a</a> or <a href="https://usaultimate.org/rules/#15.A.3.b">15.A.3.b</a>), the stall count resumes at six.</li>
+                            </ul>
                         </li>
                         <li>
-                            <a id="15.B.7"></a>Double team: If a
+                            <a id="15.B.7">15.B.7.</a> Double team: If a
                             <span class="tooltip" title="A player whose team is not in possession of the disc. A defensive player may not pick up a live disc or a disc in play or call for a pass from the thrower.">defensive player</span>
                             other than the
                             <span class="tooltip" title="The defensive player within ten feet of the thrower&#39;s pivot or of the thrower if no pivot has been established. If the disc is not in a player&#39;s possession, a defensive player within ten feet of a spot on the field where the disc is to be put into play is considered the marker.">marker</span>
@@ -1482,44 +1487,44 @@
                             <span class="annotation">[[“Merely running” means running for the exclusive purpose of reaching the other side. Running with an ulterior motive of interfering with the thrower in any way is not “merely running” and is a double team.]]</span>
                         </li>
                         <li>
-                            <a id="15.B.8"></a>Disc space:
-                            <ol>
+                            <a id="15.B.8">15.B.8.</a> Disc space:
+                            <ul>
                                 <li>
-                                    <a id="15.B.8.a"></a>It is a disc space violation if:
-                                    <ol>
+                                    <a id="15.B.8.a">15.B.8.a.</a> It is a disc space violation if:
+                                    <ul>
                                         <li>
-                                            <a id="15.B.8.a.1"></a>any part of the
+                                            <a id="15.B.8.a.1">15.B.8.a.1.</a> any part of the
                                             <span class="tooltip" title="The defensive player within ten feet of the thrower&#39;s pivot or of the thrower if no pivot has been established. If the disc is not in a player&#39;s possession, a defensive player within ten feet of a spot on the field where the disc is to be put into play is considered the marker.">marker</span>
                                             is less than one disc diameter away from the torso of the thrower; or
                                         </li>
                                         <li>
-                                            <a id="15.B.8.a.2"></a>a line between any two points on the
+                                            <a id="15.B.8.a.2">15.B.8.a.2.</a> a line between any two points on the
                                             <span class="tooltip" title="The defensive player within ten feet of the thrower&#39;s pivot or of the thrower if no pivot has been established. If the disc is not in a player&#39;s possession, a defensive player within ten feet of a spot on the field where the disc is to be put into play is considered the marker.">marker</span>
-                                            <ol>
-                                                <li><a id="15.B.8.a.2.a"></a>touches the thrower; or</li>
-                                                <li><a id="15.B.8.a.2.b"></a>is less than one disc diameter away from the torso or pivot of the thrower.</li>
-                                            </ol>
+                                            <ul>
+                                                <li><a id="15.B.8.a.2.a">15.B.8.a.2.a.</a> touches the thrower; or</li>
+                                                <li><a id="15.B.8.a.2.b">15.B.8.a.2.b.</a> is less than one disc diameter away from the torso or pivot of the thrower.</li>
+                                            </ul>
                                         </li>
-                                    </ol>
+                                    </ul>
                                 </li>
 
                                 <li>
-                                    <a id="15.B.8.b"></a>Straddle: If a line between the
+                                    <a id="15.B.8.b">15.B.8.b.</a> Straddle: If a line between the
                                     <span class="tooltip" title="The defensive player within ten feet of the thrower&#39;s pivot or of the thrower if no pivot has been established. If the disc is not in a player&#39;s possession, a defensive player within ten feet of a spot on the field where the disc is to be put into play is considered the marker.">marker's</span>
                                     feet is less than one disc diameter away from the pivot of the thrower, it is a straddle violation.
                                 </li>
                                 <li>
-                                    <a id="15.B.8.c"></a>Wrapping: If a line between the
+                                    <a id="15.B.8.c">15.B.8.c.</a> Wrapping: If a line between the
                                     <span class="tooltip" title="The defensive player within ten feet of the thrower&#39;s pivot or of the thrower if no pivot has been established. If the disc is not in a player&#39;s possession, a defensive player within ten feet of a spot on the field where the disc is to be put into play is considered the marker.">marker's</span>
                                     hands is less than one disc diameter away from the torso or pivot of the thrower, it is a wrapping violation.
                                     <span class="annotation">[[The thrower may choose to call “disc space” for both straddle and wrapping violations as they are a subset of disc space violations. However, the thrower may also choose to call the more specific violation for clearer communication to the marker about what needs to be corrected.]]</span>
                                 </li>
-                                <li><a id="15.B.8.d"></a>However, if any of the above situations are caused solely by movement of the thrower, it is not a violation.</li>
-                            </ol>
+                                <li><a id="15.B.8.d">15.B.8.d.</a> However, if any of the above situations are caused solely by movement of the thrower, it is not a violation.</li>
+                            </ul>
                         </li>
-                        <li><a id="15.B.9"></a>Vision blocking: If the <span class="tooltip" title="The defensive player within ten feet of the thrower&#39;s pivot or of the thrower if no pivot has been established. If the disc is not in a player&#39;s possession, a defensive player within ten feet of a spot on the field where the disc is to be put into play is considered the marker.">marker</span> deliberately blocks the thrower's vision, it is a vision blocking violation.</li>
+                        <li><a id="15.B.9">15.B.9.</a> Vision blocking: If the <span class="tooltip" title="The defensive player within ten feet of the thrower&#39;s pivot or of the thrower if no pivot has been established. If the disc is not in a player&#39;s possession, a defensive player within ten feet of a spot on the field where the disc is to be put into play is considered the marker.">marker</span> deliberately blocks the thrower's vision, it is a vision blocking violation.</li>
                         <li>
-                            <a id="15.B.10"></a>The
+                            <a id="15.B.10">15.B.10.</a> The
                             <span class="tooltip" title="The defensive player within ten feet of the thrower&#39;s pivot or of the thrower if no pivot has been established. If the disc is not in a player&#39;s possession, a defensive player within ten feet of a spot on the field where the disc is to be put into play is considered the marker.">marker</span>
                             may contest a marking violation by calling “violation.” This contest is treated as the call of an offensive violation, and the Continuation Rule (<a href="https://usaultimate.org/rules/#17.C">17.C</a>) applies.
                             <span class="annotation"
@@ -1527,112 +1532,112 @@
                                 is the thrower's responsibility to stop play as soon as possible after the marker makes their call contesting the marking violation (<a href="https://usaultimate.org/rules/#20.F">20.F</a>).]]</span
                             >
                         </li>
-                        <li><a id="15.B.11"></a>Flagrant marking infractions are immediately callable as a general violation and are also covered under <a href="https://usaultimate.org/rules/#2.C.1">2.C.1</a>. <span class="annotation">[[One example of a flagrant marking infraction would be skipping multiple numbers or intervals at a time in a stall count.]]</span></li>
-                    </ol>
+                        <li><a id="15.B.11">15.B.11.</a> Flagrant marking infractions are immediately callable as a general violation and are also covered under <a href="https://usaultimate.org/rules/#2.C.1">2.C.1</a>. <span class="annotation">[[One example of a flagrant marking infraction would be skipping multiple numbers or intervals at a time in a stall count.]]</span></li>
+                    </ul>
                 </li>
-            </ol>
+            </ul>
         </li>
 
         <li>
-            <a id="16"></a>The Receiver
-            <ol>
+            <a id="16">16.</a> The Receiver
+            <ul>
                 <li>
-                    <a id="16.A"></a>A player may bobble the disc in order to gain control of it, but purposeful bobbling (including tipping, delaying, guiding, brushing or the like) to oneself in order to advance the disc in any direction from where it initially was contacted is considered traveling.
+                    <a id="16.A">16.A.</a> A player may bobble the disc in order to gain control of it, but purposeful bobbling (including tipping, delaying, guiding, brushing or the like) to oneself in order to advance the disc in any direction from where it initially was contacted is considered traveling.
                     <span class="annotation">[[Tipping, brushing, etc. to someone else is legal. It is legal to tip/brush your own throw. However, if after a tip/brush, one is the first player to touch the disc, then it is deemed a tip/brush to oneself and it is a travel.]]</span>
                     <span class="annotation">[[Remember, you can bobble for the purpose of gaining control, so kicking the disc up to yourself to help catch it would be legal. But tipping the disc for the purpose of evading a defender would not be legal.]]</span>
                 </li>
-                <li><a id="16.B"></a>After catching a pass, a player is required to come to a stop as quickly as possible and establish a pivot.</li>
+                <li><a id="16.B">16.B.</a> After catching a pass, a player is required to come to a stop as quickly as possible and establish a pivot.</li>
                 <li>
-                    <a id="16.C"></a>If a player catches the disc while running or jumping the player may release a pass without attempting to stop and without setting a pivot, provided that:
-                    <ol>
+                    <a id="16.C">16.C.</a> If a player catches the disc while running or jumping the player may release a pass without attempting to stop and without setting a pivot, provided that:
+                    <ul>
                         <li>
-                            <a id="16.C.1"></a>the player does not change direction or increase speed while in
+                            <a id="16.C.1">16.C.1.</a> the player does not change direction or increase speed while in
                             <span class="tooltip" title="Sustained contact with, and control of, a non-spinning disc.">possession</span>
                             of the disc; and
                         </li>
                         <li>
-                            <a id="16.C.2"></a>the pass is released before three additional points of contact with the ground are made after
+                            <a id="16.C.2">16.C.2.</a> the pass is released before three additional points of contact with the ground are made after
                             <span class="tooltip" title="Sustained contact with, and control of, a non-spinning disc.">possession</span>
                             has been established.
                         </li>
-                    </ol>
+                    </ul>
                 </li>
 
-                <li><a id="16.D"></a>If offensive and defensive players catch the disc simultaneously, the offense retains possession.</li>
+                <li><a id="16.D">16.D.</a> If offensive and defensive players catch the disc simultaneously, the offense retains possession.</li>
                 <li>
-                    <a id="16.E"></a>If it is unclear whether a catch was made before the disc contacted the ground (grass is considered part of the ground), or whether a player's first point of
+                    <a id="16.E">16.E.</a> If it is unclear whether a catch was made before the disc contacted the ground (grass is considered part of the ground), or whether a player's first point of
                     <span class="tooltip" title="All player contact with the ground directly related to a specific event or maneuver (e.g., jumping, diving, leaning or falling), including landing or recovering after being off-balance. Items on the ground are considered part of the ground.">ground contact</span>
                     after catching the disc was in- or out-of-bounds or in or out of the end zone, the player with the
                     <span class="tooltip" title="The most complete view available by a player that includes the relative positions of the disc, ground, players, and line markers involved in a play. On an unlined field, this may require sighting from one field marker to another.">best perspective</span>
                     makes the call.
                 </li>
-            </ol>
+            </ul>
         </li>
 
         <li>
-            <a id="17"></a>Violations and Fouls
-            <ol>
+            <a id="17">17.</a> Violations and Fouls
+            <ul>
                 <li>
-                    <a id="17.A"></a>Unless specified differently elsewhere, an infraction may only be called by a player on the infracted team who recognizes that it has occurred.
+                    <a id="17.A">17.A.</a> Unless specified differently elsewhere, an infraction may only be called by a player on the infracted team who recognizes that it has occurred.
                     <span class="annotation">[[The player must know that a specific rule was violated and have perceived the particular action with certainty. A player may not call an infraction whenever the player maybe recognizes that some infraction might have occurred.]]</span>
                     The player must immediately call “violation” or the name of the specific infraction loudly.
                 </li>
                 <li>
-                    <a id="17.B"></a>A player called for an infraction may contest that call if that player believes the infraction did not occur.
+                    <a id="17.B">17.B.</a> A player called for an infraction may contest that call if that player believes the infraction did not occur.
                     <span class="annotation">[[This belief may be based on the player's perspective on the particular sequence of events or based on a disagreement over the application of the rules, provided the player has read and understands the rules. For example, “No, I didn't slap your hand” or “Tipping the disc to someone else is not a travel.”]]</span>
                 </li>
                 <li>
-                    <a id="17.C"></a>Any time an infraction is called, the Continuation Rule applies. Continuation Rule: Play stops when the thrower in possession acknowledges that an infraction has been called.
+                    <a id="17.C">17.C.</a> Any time an infraction is called, the Continuation Rule applies. Continuation Rule: Play stops when the thrower in possession acknowledges that an infraction has been called.
                     <span class="annotation">[[This refers to the thrower who possesses the disc or has just released the disc at the time of the infraction/call. Who the thrower (<a href="https://usaultimate.org/rules/#3.O.5">3.O.5</a>) is is determined at the time of the infraction/call.]]</span>
                     If a call is made when the disc is in the air or the thrower is in the act of throwing, or if the thrower fails to acknowledge the call and subsequently attempts a pass, play continues until the outcome of that pass is determined. For the purpose of the Continuation Rule, an uncontested stall that occurs after another call is treated the same as an incomplete pass.
                     <span class="annotation">[[Thus, if you get stalled before you acknowledge a call, it is treated the same as if you ignored the call and threw a turnover.]]</span>
                     Play then either stops or continues according to the following:
-                    <ol>
-                        <li><a id="17.C.1"></a>Despite any outcome dictated by these rules, if the involved players on both teams agree that the infraction did not affect the outcome of the play, play stops and the result of the play stands. This provision does not apply if the thrower is aware an infraction has been called and subsequently attempts a pass.</li>
-                        <li><a id="17.C.2"></a>Where the outcome of these rules is for play to continue unhalted, the player who called the infraction must announce “play on.” Additionally, any player recognizing that play should continue without stoppage should announce “play on.” If the player who called the infraction does not announce “play on” and the opposing team is uncertain whether play should continue, the opposing team has the option to stop play by calling “violation.”</li>
+                    <ul>
+                        <li><a id="17.C.1">17.C.1.</a> Despite any outcome dictated by these rules, if the involved players on both teams agree that the infraction did not affect the outcome of the play, play stops and the result of the play stands. This provision does not apply if the thrower is aware an infraction has been called and subsequently attempts a pass.</li>
+                        <li><a id="17.C.2">17.C.2.</a> Where the outcome of these rules is for play to continue unhalted, the player who called the infraction must announce “play on.” Additionally, any player recognizing that play should continue without stoppage should announce “play on.” If the player who called the infraction does not announce “play on” and the opposing team is uncertain whether play should continue, the opposing team has the option to stop play by calling “violation.”</li>
                         <li>
-                            <a id="17.C.3"></a>For calls made by the offense:
-                            <ol>
+                            <a id="17.C.3">17.C.3.</a> For calls made by the offense:
+                            <ul>
                                 <li>
-                                    <a id="17.C.3.a"></a>If the pass is complete:
-                                    <ol>
-                                        <li><a id="17.C.3.a.1"></a>If the offense called the infraction before the thrower began the act of throwing (<a href="https://usaultimate.org/rules/#3.O.3">3.O.3</a>), play stops and possession reverts to the thrower.</li>
-                                        <li><a id="17.C.3.a.2"></a>If the offense called the infraction after the thrower began the act of throwing, play continues unhalted.</li>
+                                    <a id="17.C.3.a">17.C.3.a.</a> If the pass is complete:
+                                    <ul>
+                                        <li><a id="17.C.3.a.1">17.C.3.a.1.</a> If the offense called the infraction before the thrower began the act of throwing (<a href="https://usaultimate.org/rules/#3.O.3">3.O.3</a>), play stops and possession reverts to the thrower.</li>
+                                        <li><a id="17.C.3.a.2">17.C.3.a.2.</a> If the offense called the infraction after the thrower began the act of throwing, play continues unhalted.</li>
                                         <li>
-                                            <a id="17.C.3.a.3"></a>Where an infraction is called by the thrower, players should treat the call as if it was made when the infraction occurred in determining whether the call was made before or after the thrower was in the act of throwing. If the infraction occurred after the throw was released, the call is considered to have been made by a non-thrower.
+                                            <a id="17.C.3.a.3">17.C.3.a.3.</a> Where an infraction is called by the thrower, players should treat the call as if it was made when the infraction occurred in determining whether the call was made before or after the thrower was in the act of throwing. If the infraction occurred after the throw was released, the call is considered to have been made by a non-thrower.
                                             <span class="annotation">[[This means that if you throw a turnover and call a foul on contact after the release, the turnover will generally stand. Note that the timing is based on when the infraction occurred for this rule.]]</span>
                                         </li>
-                                    </ol>
+                                    </ul>
                                 </li>
 
                                 <li>
-                                    <a id="17.C.3.b"></a>If the pass is incomplete:
-                                    <ol>
-                                        <li><a id="17.C.3.b.1"></a>If the infraction affected the play (<a href="https://usaultimate.org/rules/#17.C.5">17.C.5</a>), play stops and the disc reverts to the thrower unless the specific rule (e.g., the receiving foul rule) says otherwise.</li>
-                                        <li><a id="17.C.3.b.2"></a>If the infraction did not affect the play, play stops and the result of the play stands.</li>
-                                        <li><a id="17.C.3.b.3"></a>Where the thrower calls an infraction which occurred before the thrower began the act of throwing, play continues unhalted and the result of the play stands.</li>
-                                    </ol>
+                                    <a id="17.C.3.b">17.C.3.b.</a> If the pass is incomplete:
+                                    <ul>
+                                        <li><a id="17.C.3.b.1">17.C.3.b.1.</a> If the infraction affected the play (<a href="https://usaultimate.org/rules/#17.C.5">17.C.5</a>), play stops and the disc reverts to the thrower unless the specific rule (e.g., the receiving foul rule) says otherwise.</li>
+                                        <li><a id="17.C.3.b.2">17.C.3.b.2.</a> If the infraction did not affect the play, play stops and the result of the play stands.</li>
+                                        <li><a id="17.C.3.b.3">17.C.3.b.3.</a> Where the thrower calls an infraction which occurred before the thrower began the act of throwing, play continues unhalted and the result of the play stands.</li>
+                                    </ul>
                                 </li>
-                            </ol>
+                            </ul>
                         </li>
 
                         <li>
-                            <a id="17.C.4"></a>For calls made by the defense:
-                            <ol>
+                            <a id="17.C.4">17.C.4.</a> For calls made by the defense:
+                            <ul>
                                 <li>
-                                    <a id="17.C.4.a"></a>If the pass is complete:
-                                    <ol>
-                                        <li><a id="17.C.4.a.1"></a>If the infraction affected the play (<a href="https://usaultimate.org/rules/#17.C.5">17.C.5</a>), play stops and the disc reverts to the thrower unless the specific rule (e.g., the receiving foul rule) says otherwise.</li>
-                                        <li><a id="17.C.4.a.2"></a>If the infraction did not affect the play, play stops and the result of the play stands.</li>
-                                    </ol>
+                                    <a id="17.C.4.a">17.C.4.a.</a> If the pass is complete:
+                                    <ul>
+                                        <li><a id="17.C.4.a.1">17.C.4.a.1.</a> If the infraction affected the play (<a href="https://usaultimate.org/rules/#17.C.5">17.C.5</a>), play stops and the disc reverts to the thrower unless the specific rule (e.g., the receiving foul rule) says otherwise.</li>
+                                        <li><a id="17.C.4.a.2">17.C.4.a.2.</a> If the infraction did not affect the play, play stops and the result of the play stands.</li>
+                                    </ul>
                                 </li>
 
-                                <li><a id="17.C.4.b"></a>If the pass is incomplete, play continues un-halted.</li>
-                            </ol>
+                                <li><a id="17.C.4.b">17.C.4.b.</a> If the pass is incomplete, play continues un-halted.</li>
+                            </ul>
                         </li>
 
                         <li>
-                            <a id="17.C.5"></a>An infraction affected the play if an infracted player determines that the outcome of the specific play, from the time of the infraction until play stops, may have been meaningfully different absent the infraction.
+                            <a id="17.C.5">17.C.5.</a> An infraction affected the play if an infracted player determines that the outcome of the specific play, from the time of the infraction until play stops, may have been meaningfully different absent the infraction.
                             <span class="annotation"
                                 >[[It is the infracted player's responsibility to announce if play was affected. For example, if a defender calls “pick” while trailing a receiver by 6 feet, the defender should indicate whether the pick affected the play. If the pick did not affect the play, the defender will still recover any distance lost, but the
                                 <span class="tooltip" title="Any catch that results in the team in possession of the disc retaining possession. Any pass that is not complete is incomplete.">completed pass</span>
@@ -1642,70 +1647,70 @@
                             <span class="annotation">[[Contact that occurs after the outcome of the play is determined cannot affect the play. For example, if a defender catches a disc before lightly bumping into the receiver, that contact did not affect the play and the turnover will stand.]]</span>
                         </li>
                         <li>
-                            <a id="17.C.6"></a>Positioning after a call:
-                            <ol>
-                                <li><a id="17.C.6.a"></a>If no pass is thrown or attempted before the thrower stops play by acknowledging the call, all players return to the locations they occupied when the call was made.</li>
+                            <a id="17.C.6">17.C.6.</a> Positioning after a call:
+                            <ul>
+                                <li><a id="17.C.6.a">17.C.6.a.</a> If no pass is thrown or attempted before the thrower stops play by acknowledging the call, all players return to the locations they occupied when the call was made.</li>
                                 <li>
-                                    <a id="17.C.6.b"></a>If a pass is thrown or attempted before the thrower acknowledges the call or the call is made after the throwing attempt, and
-                                    <ol>
+                                    <a id="17.C.6.b">17.C.6.b.</a> If a pass is thrown or attempted before the thrower acknowledges the call or the call is made after the throwing attempt, and
+                                    <ul>
                                         <li>
-                                            <a id="17.C.6.b.1"></a>if possession reverts to the thrower, all players return to the locations they occupied at the earlier of:
+                                            <a id="17.C.6.b.1">17.C.6.b.1.</a> if possession reverts to the thrower, all players return to the locations they occupied at the earlier of:
                                             <span class="annotation">[[Therefore, if a long pass is thrown and there is a contested receiving foul, the players will return to where they were at the time of the throw (rather than remaining downfield after chasing down the disc).]]</span>
-                                            <ol>
-                                                <li><a id="17.C.6.b.1.a"></a>the time of the throw,</li>
-                                                <li><a id="17.C.6.b.1.b"></a>the time of the call.</li>
-                                            </ol>
+                                            <ul>
+                                                <li><a id="17.C.6.b.1.a">17.C.6.b.1.a.</a> the time of the throw,</li>
+                                                <li><a id="17.C.6.b.1.b">17.C.6.b.1.b.</a> the time of the call.</li>
+                                            </ul>
                                         </li>
 
-                                        <li><a id="17.C.6.b.2"></a>if a player other than the thrower is awarded possession due to an uncontested call, all players return to the locations they occupied at the time of the infraction.</li>
-                                        <li><a id="17.C.6.b.3"></a>if the result of a play stands, players return to the locations they occupied when play stopped.</li>
-                                    </ol>
+                                        <li><a id="17.C.6.b.2">17.C.6.b.2.</a> if a player other than the thrower is awarded possession due to an uncontested call, all players return to the locations they occupied at the time of the infraction.</li>
+                                        <li><a id="17.C.6.b.3">17.C.6.b.3.</a> if the result of a play stands, players return to the locations they occupied when play stopped.</li>
+                                    </ul>
                                 </li>
-                            </ol>
+                            </ul>
                         </li>
-                    </ol>
+                    </ul>
                 </li>
 
                 <li>
-                    <a id="17.D"></a>If a player makes a play-halting call and subsequently determines that their call was incorrect, they should retract the call by announcing “retracted.” Play still stops. Play restarts with a check and the stall resumes according to <a href="https://usaultimate.org/rules/#15.A.5.a">15.A.5.a</a>.
+                    <a id="17.D">17.D.</a> If a player makes a play-halting call and subsequently determines that their call was incorrect, they should retract the call by announcing “retracted.” Play still stops. Play restarts with a check and the stall resumes according to <a href="https://usaultimate.org/rules/#15.A.5.a">15.A.5.a</a>.
                     <span class="annotation">[[This includes a player incorrectly stopping play because they thought they heard a call such as “pick” and echoed the call.]]</span>
                 </li>
-                <li><a id="17.E"></a>If a dispute arises concerning an infraction or the outcome of a play (e.g., a catch where no one had a good perspective), and the teams cannot come to a satisfactory resolution, play stops, and the disc is returned to the thrower and put into play with a check (<a href="https://usaultimate.org/rules/#9.D">9.D</a>), with the count reached plus one or at six if over five.</li>
+                <li><a id="17.E">17.E.</a> If a dispute arises concerning an infraction or the outcome of a play (e.g., a catch where no one had a good perspective), and the teams cannot come to a satisfactory resolution, play stops, and the disc is returned to the thrower and put into play with a check (<a href="https://usaultimate.org/rules/#9.D">9.D</a>), with the count reached plus one or at six if over five.</li>
                 <li>
-                    <a id="17.F"></a>Any player may stop a rolling or sliding disc, but advancing it in any direction is a violation.
-                    <ol>
-                        <li><a id="17.F.1"></a>If the offense commits this violation, it is a travel and is resolved according to <a href="https://usaultimate.org/rules/#17.K.3">17.K.3</a>. <span class="annotation">[[Play does not stop. The defense must call “travel” and indicate the spot on the field where the infraction occurred. The marker may not initiate the stall count until the thrower has set their pivot at that spot, and the thrower may not attempt a pass until setting their pivot and touching the disc to the ground.]]</span></li>
-                        <li><a id="17.F.2"></a>If the defense commits this violation, the thrower may inform the defense of the infraction without stopping play. The thrower must indicate where the infraction occurred and put the disc into play at that spot.</li>
-                        <li><a id="17.F.3"></a>Any player on the team allegedly committing this violation may contest this call by calling “violation” and stopping play.</li>
-                    </ol>
+                    <a id="17.F">17.F.</a> Any player may stop a rolling or sliding disc, but advancing it in any direction is a violation.
+                    <ul>
+                        <li><a id="17.F.1">17.F.1.</a> If the offense commits this violation, it is a travel and is resolved according to <a href="https://usaultimate.org/rules/#17.K.3">17.K.3</a>. <span class="annotation">[[Play does not stop. The defense must call “travel” and indicate the spot on the field where the infraction occurred. The marker may not initiate the stall count until the thrower has set their pivot at that spot, and the thrower may not attempt a pass until setting their pivot and touching the disc to the ground.]]</span></li>
+                        <li><a id="17.F.2">17.F.2.</a> If the defense commits this violation, the thrower may inform the defense of the infraction without stopping play. The thrower must indicate where the infraction occurred and put the disc into play at that spot.</li>
+                        <li><a id="17.F.3">17.F.3.</a> Any player on the team allegedly committing this violation may contest this call by calling “violation” and stopping play.</li>
+                    </ul>
                 </li>
                 <li>
-                    <a id="17.G"></a>If an infraction results in possession reverting to a thrower who was airborne when releasing the disc, play restarts at the spot on the playing field closest to the point of release.
+                    <a id="17.G">17.G.</a> If an infraction results in possession reverting to a thrower who was airborne when releasing the disc, play restarts at the spot on the playing field closest to the point of release.
                     <span class="annotation">[[This applies to throwers attempting a “greatest” or any other airborne thrower.]]</span>
                 </li>
                 <li>
-                    <a id="17.H"></a>If multiple infractions occur on the same play or before play stops, the outcomes should be resolved in reverse sequence (latest infraction first, earliest infraction last).
-                    <ol>
+                    <a id="17.H">17.H.</a> If multiple infractions occur on the same play or before play stops, the outcomes should be resolved in reverse sequence (latest infraction first, earliest infraction last).
+                    <ul>
                         <li>
-                            <a id="17.H.1"></a>If an earlier infraction is determined not to have affected the play (<a href="https://usaultimate.org/rules/#17.C.1">17.C.1</a> and <a href="https://usaultimate.org/rules/#17.C.5">17.C.5</a>), that infraction is not resolved and it does not affect the resolution of subsequent infractions.
+                            <a id="17.H.1">17.H.1.</a> If an earlier infraction is determined not to have affected the play (<a href="https://usaultimate.org/rules/#17.C.1">17.C.1</a> and <a href="https://usaultimate.org/rules/#17.C.5">17.C.5</a>), that infraction is not resolved and it does not affect the resolution of subsequent infractions.
                             <span class="annotation">[[Not resolved essentially means that the call is treated as if it had not occurred and the result of the play (possession, stall count, etc.) is unchanged by that call.]]</span>
                         </li>
                         <li>
-                            <a id="17.H.2"></a>Offsetting infractions: If both offensive and defensive infractions occur simultaneously or the sequence cannot be determined, the resolution for this set of infractions is: the disc is returned to the thrower and put into play with a check, with the count reached plus one or at six if over five.
+                            <a id="17.H.2">17.H.2.</a> Offsetting infractions: If both offensive and defensive infractions occur simultaneously or the sequence cannot be determined, the resolution for this set of infractions is: the disc is returned to the thrower and put into play with a check, with the count reached plus one or at six if over five.
                             <span class="annotation">[[It is possible that resolutions to earlier infractions may ultimately change this particular outcome.]]</span>
                         </li>
                         <li>
-                            <a id="17.H.3"></a>Exception: If separate
+                            <a id="17.H.3">17.H.3.</a> Exception: If separate
                             <span class="tooltip" title="Non-Incidental contact: contact between opposing players (see 3.F for a definition of incidental contact). In general, the player initiating the contact has committed the foul.">fouls</span>
                             occur while the disc is in the air, but before any player starts to attempt to catch or block the disc, those
                             <span class="tooltip" title="Non-Incidental contact: contact between opposing players (see 3.F for a definition of incidental contact). In general, the player initiating the contact has committed the foul.">fouls</span>
                             are treated as simultaneous and on the same play.
                         </li>
-                    </ol>
+                    </ul>
 
                     <span class="annotation"
                         >[[Examples: <br />
-                        <ul>
+                        <ul class="examples">
                             <li class="annotation">
                                 A receiver and their opponent contact each other and both call fouls against the other.
                                 <a href="https://usaultimate.org/rules/#17.H.2">17.H.2</a> applies, and the disc is returned to the thrower and put into play with a check, with the count reached plus one or at six if over five.
@@ -1721,14 +1726,14 @@
                 </li>
 
                 <li>
-                    <a id="17.I"></a>Fouls (<a href="https://usaultimate.org/rules/#3.C">3.C</a>): It is the responsibility of all players to avoid initiating contact in every way possible.
+                    <a id="17.I">17.I.</a> Fouls (<a href="https://usaultimate.org/rules/#3.C">3.C</a>): It is the responsibility of all players to avoid initiating contact in every way possible.
                     <span class="annotation">[[Avoid initiating contact in every way reasonably possible, while still playing ultimate. Some contact is inevitable, but players have an affirmative obligation to make reasonable efforts to avoid initiating contact. This includes, but is not exclusive to, contact initiated with non-throwers (i.e., cutters and handlers) prior to starting or restarting play, as well as mid-play. Moreover, in instances of severe contact, such as a violent collision, a player anticipating a violent collision has responsibility to avoid the collision, even if not initiated by the player; one may not attempt to “win the collision.”]]</span>
-                    <ol>
+                    <ul>
                         <li>
-                            <a id="17.I.1"></a>Dangerous Play. Actions demonstrating reckless disregard for the safety of or posing a significant risk of injury to fellow players, or other dangerously aggressive behavior are considered “dangerous play” and are treated as a <span class="tooltip" title="Non-Incidental contact: contact between opposing players (see 3.F for a definition of incidental contact). In general, the player initiating the contact has committed the foul.">foul</span>. The proper call in such circumstances is “dangerous play” and play stops. This rule is not superseded by any other rule.
+                            <a id="17.I.1">17.I.1.</a> Dangerous Play. Actions demonstrating reckless disregard for the safety of or posing a significant risk of injury to fellow players, or other dangerously aggressive behavior are considered “dangerous play” and are treated as a <span class="tooltip" title="Non-Incidental contact: contact between opposing players (see 3.F for a definition of incidental contact). In general, the player initiating the contact has committed the foul.">foul</span>. The proper call in such circumstances is “dangerous play” and play stops. This rule is not superseded by any other rule.
                             <span class="annotation"
                                 >[[The following are non-exhaustive examples of dangerous play:
-                                <ul>
+                                <ul class="examples">
                                     <li class="annotation">significantly colliding with a mostly stationary opponent,</li>
                                     <li class="annotation">jumping into a group of mostly stationary players,</li>
                                     <li class="annotation">diving around or through a player that results in contact with a player's back or legs,</li>
@@ -1740,56 +1745,56 @@
                                     <li class="annotation">jumping right in front of a sprinting player in a manner where contact is unavoidable]]</li>
                                 </ul>
                             </span>
-                            <ol>
+                            <ul>
                                 <li>
-                                    <a id="17.I.1.a"></a>Dangerous play is considered a foul regardless of whether or when the disc arrives or contact occurs.
-                                    <ol>
+                                    <a id="17.I.1.a">17.I.1.a.</a> Dangerous play is considered a foul regardless of whether or when the disc arrives or contact occurs.
+                                    <ul>
                                         <li>
-                                            <a id="17.I.1.a.1"></a>The vast majority of dangerous play will involve contact between players. However, contact is not required for a player to invoke this rule where there is reasonable certainty that contact would have occurred had the player not taken steps to avoid contact.
+                                            <a id="17.I.1.a.1">17.I.1.a.1.</a> The vast majority of dangerous play will involve contact between players. However, contact is not required for a player to invoke this rule where there is reasonable certainty that contact would have occurred had the player not taken steps to avoid contact.
                                             <span class="annotation">[[A player is not required to hold their position and receive contact in order to call “dangerous play,” but the mere possibility of contact is insufficient to justify a call. Furthermore, if the offending player stops or changes their path such that contact would not have occurred, contact was not “reasonably certain.”]]</span>
                                         </li>
-                                    </ol>
+                                    </ul>
                                 </li>
 
                                 <li>
-                                    <a id="17.I.1.b"></a>Resolution. If uncontested, a call of “dangerous play” is resolved as an analogous foul (e.g., if the call occurred while or immediately after the calling player was making a play on a disc in the air, it is treated as a Receiving Foul (<a href="https://usaultimate.org/rules/#17.I.4.b">17.I.4.b</a>)). A player called for dangerous play may contest the call if they believe the call was incorrect (<a href="https://usaultimate.org/rules/#17.B">17.B</a>).
-                                    <ol>
+                                    <a id="17.I.1.b">17.I.1.b.</a> Resolution. If uncontested, a call of “dangerous play” is resolved as an analogous foul (e.g., if the call occurred while or immediately after the calling player was making a play on a disc in the air, it is treated as a Receiving Foul (<a href="https://usaultimate.org/rules/#17.I.4.b">17.I.4.b</a>)). A player called for dangerous play may contest the call if they believe the call was incorrect (<a href="https://usaultimate.org/rules/#17.B">17.B</a>).
+                                    <ul>
                                         <li>
-                                            <a id="17.I.1.b.1"></a>Dangerous play between a thrower and
+                                            <a id="17.I.1.b.1">17.I.1.b.1.</a> Dangerous play between a thrower and
                                             <span class="tooltip" title="The defensive player within ten feet of the thrower&#39;s pivot or of the thrower if no pivot has been established. If the disc is not in a player&#39;s possession, a defensive player within ten feet of a spot on the field where the disc is to be put into play is considered the marker.">marker</span>
                                             is treated as a throwing foul that affected the play, regardless of whether or when the disc is released or when contact occurs, unless the calling player determines otherwise.
                                         </li>
                                         <li>
-                                            <a id="17.I.1.b.2"></a>Dangerous play occurring when or immediately after the disc is in the air is treated as a receiving foul if either player involved is attempting a play on the disc. However, the calling player may elect to treat the dangerous play as a general foul, if the player determines that the dangerous play was unrelated to the overall play that decided the outcome of the action.
+                                            <a id="17.I.1.b.2">17.I.1.b.2.</a> Dangerous play occurring when or immediately after the disc is in the air is treated as a receiving foul if either player involved is attempting a play on the disc. However, the calling player may elect to treat the dangerous play as a general foul, if the player determines that the dangerous play was unrelated to the overall play that decided the outcome of the action.
                                             <span class="annotation"
                                                 >[[For example, if a third player appears and grabs the disc far before it reaches the two involved players, or if the disc is thrown to the opposite side of the field, the involved players will not be attempting a play on the disc. However, if multiple players accumulate under a floating disc, one player's dangerous play will be treated as a receiving foul, even if a third player happens to make a successful play on the disc, as the players under the disc were attempting a play on the disc. The calling player would have discretion to deem the third player's play so independent and removed from the involved players that the calling player wishes to treat the dangerous play as a general foul rather than a receiving foul. In general, a calling player's decision that a dangerous play was unrelated to the overall play will be based on the dangerous play being removed in significant distance or time from the overall play. By way of further
                                                 example, even a dangerous play committed against a player unaware of the approaching disc will be treated as a receiving foul, where the offending player was attempting to make a play on the disc, giving the benefit of the doubt that the calling player could potentially have become aware of the approaching disc, had the offending player made a safe play. In this instance, the calling player could determine that it would not have been possible to become aware of the disc such that the outcome of the play would have changed and therefore elect to treat the dangerous play as a general foul.]]</span
                                             >
                                         </li>
                                         <li>
-                                            <a id="17.I.1.b.3"></a>Dangerous play is treated as a general foul only if it occurs when the disc is not in the air, occurs far away from the disc, when the disc is obviously uncatchable, or when the calling player has elected such treatment under <a href="https://usaultimate.org/rules/#17.I.1.b.2">17.I.1.b.2</a>. In this situation, the calling player determines whether the play was affected, under the standard enunciated in this rule and its annotations.
+                                            <a id="17.I.1.b.3">17.I.1.b.3.</a> Dangerous play is treated as a general foul only if it occurs when the disc is not in the air, occurs far away from the disc, when the disc is obviously uncatchable, or when the calling player has elected such treatment under <a href="https://usaultimate.org/rules/#17.I.1.b.2">17.I.1.b.2</a>. In this situation, the calling player determines whether the play was affected, under the standard enunciated in this rule and its annotations.
                                             <span class="annotation">[[A disc is obviously uncatchable only when it hits the ground before a catch could possibly be made, is out-of-bounds with no possibility of an in-bounds completion, or otherwise presents no opportunity for a catch (whether initial or subsequent efforts), giving every benefit of the doubt to the calling player.]]</span>
                                             <span class="annotation">[[In determining whether a dangerous play affected the play under <a href="https://usaultimate.org/rules/#17.I.1.b.3">17.I.1.b.3</a>, the calling player should broadly consider the entire play, including any approach taken by the offending player immediately before the dangerous play. A good rule of thumb is to look to the last time when a player could have still changed their actions and actively avoided a dangerous outcome but did not (the “point of no return”) through the time immediately after resolution of the play and broadly consider whether the outcome of the play could possibly have been different, had the offending player taken a safe approach. Even a player's awareness of the presence of the offending player can affect the play.]]</span>
                                         </li>
-                                    </ol>
+                                    </ul>
                                 </li>
-                            </ol>
+                            </ul>
                         </li>
 
                         <li>
-                            <a id="17.I.2"></a>A
+                            <a id="17.I.2">17.I.2.</a> A
                             <span class="tooltip" title="Non-Incidental contact: contact between opposing players (see 3.F for a definition of incidental contact). In general, the player initiating the contact has committed the foul.">foul</span>
                             can be called only by the fouled player and must be announced by loudly calling “foul” immediately after it occurs.
                         </li>
-                        <li><a id="17.I.3"></a>Non incidental contact resulting from adjacent opposing players vying for the same unoccupied position may be treated as offsetting fouls.</li>
+                        <li><a id="17.I.3">17.I.3.</a> Non incidental contact resulting from adjacent opposing players vying for the same unoccupied position may be treated as offsetting fouls.</li>
                         <li>
-                            <a id="17.I.4"></a>Some fouls carry some extra provisions, as listed below.
-                            <ol>
+                            <a id="17.I.4">17.I.4.</a> Some fouls carry some extra provisions, as listed below.
+                            <ul>
                                 <li>
-                                    <a id="17.I.4.a"></a>Throwing Fouls:
-                                    <ol>
+                                    <a id="17.I.4.a">17.I.4.a.</a> Throwing Fouls:
+                                    <ul>
                                         <li>
-                                            <a id="17.I.4.a.1"></a>A throwing foul may be called when there is non-<span class="tooltip" title="Contact between opposing players that does not affect continued play.">incidental contact</span>
+                                            <a id="17.I.4.a.1">17.I.4.a.1.</a> A throwing foul may be called when there is non-<span class="tooltip" title="Contact between opposing players that does not affect continued play.">incidental contact</span>
                                             between the thrower and
                                             <span class="tooltip" title="The defensive player within ten feet of the thrower&#39;s pivot or of the thrower if no pivot has been established. If the disc is not in a player&#39;s possession, a defensive player within ten feet of a spot on the field where the disc is to be put into play is considered the marker.">marker</span>.
                                             <span class="annotation">[[Nearly every instance of contact between the thrower and marker will be non-incidental with respect to the thrower, whether it disrupts the thrower's concentration, interferes with the thrower's movement, disturbs the thrower's grip, interferes with a throw, or affects continued play in any other way.]]</span>
@@ -1798,88 +1803,88 @@
                                             is considered part of the thrower.
                                         </li>
                                         <li>
-                                            <a id="17.I.4.a.2"></a>In general, any contact between the thrower and the extended (i.e., away from the midline of the body) arms or legs of a
+                                            <a id="17.I.4.a.2">17.I.4.a.2.</a> In general, any contact between the thrower and the extended (i.e., away from the midline of the body) arms or legs of a
                                             <span class="tooltip" title="The defensive player within ten feet of the thrower&#39;s pivot or of the thrower if no pivot has been established. If the disc is not in a player&#39;s possession, a defensive player within ten feet of a spot on the field where the disc is to be put into play is considered the marker.">marker</span>
                                             is a foul on the marker, unless the contacted area of the marker is completely stationary and in a
                                             <span class="tooltip" title="A position established by a marker that does not violate any of the provisions outlined in 15.B.">legal position</span>.
                                             <span class="annotation">[[Really completely stationary. This is very rare.]]</span>
                                         </li>
                                         <li>
-                                            <a id="17.I.4.a.3"></a>Any contact that occurs due to the marker setting up in an illegal position (<a href="https://usaultimate.org/rules/#15.B.8">15.B.8</a>) is a foul on the <span class="tooltip" title="The defensive player within ten feet of the thrower&#39;s pivot or of the thrower if no pivot has been established. If the disc is not in a player&#39;s possession, a defensive player within ten feet of a spot on the field where the disc is to be put into play is considered the marker.">marker</span>.
+                                            <a id="17.I.4.a.3">17.I.4.a.3.</a> Any contact that occurs due to the marker setting up in an illegal position (<a href="https://usaultimate.org/rules/#15.B.8">15.B.8</a>) is a foul on the <span class="tooltip" title="The defensive player within ten feet of the thrower&#39;s pivot or of the thrower if no pivot has been established. If the disc is not in a player&#39;s possession, a defensive player within ten feet of a spot on the field where the disc is to be put into play is considered the marker.">marker</span>.
                                             <span class="annotation">[[Non-incidental contact. Again, nearly all contact will be non-incidental with respect to the thrower.]]</span>
                                             <span class="annotation">[[This contact must be part of an ultimate-related maneuver (throwing, pivoting, etc.) and must occur with a part of the marker that is illegally positioned. For example, shoving the marker does not result in contact due to the marker setting up an illegal position. Similarly, if a marker is providing disc space, except for illegally wrapping the thrower with their arms, only contact with the illegally positioned arms is due to the marker setting up an illegal position.]]</span>
                                             Once the marker has set up in a legal marking position, it is the responsibility of both players to respect this
                                             <span class="tooltip" title="A position established by a marker that does not violate any of the provisions outlined in 15.B.">legal position</span>. However, contact resulting from the thrower and the marker both vying for the same unoccupied position is a foul on the marker.
                                         </li>
                                         <li>
-                                            <a id="17.I.4.a.4"></a>Any contact initiated by a thrower with the body (excluding arms and legs extended from the midline of the body) of a legally positioned (<a href="https://usaultimate.org/rules/#15.B.8">15.B.8</a>)
+                                            <a id="17.I.4.a.4">17.I.4.a.4.</a> Any contact initiated by a thrower with the body (excluding arms and legs extended from the midline of the body) of a legally positioned (<a href="https://usaultimate.org/rules/#15.B.8">15.B.8</a>)
                                             <span class="tooltip" title="The defensive player within ten feet of the thrower&#39;s pivot or of the thrower if no pivot has been established. If the disc is not in a player&#39;s possession, a defensive player within ten feet of a spot on the field where the disc is to be put into play is considered the marker.">marker</span>
                                             is a foul on the thrower.
                                             <span class="annotation">[[Non-incidental contact. The effect of the contact on the marker is important here, as many, but not all, instances of contact will affect continued play with respect to the marker.]]</span>
                                         </li>
                                         <li>
-                                            <a id="17.I.4.a.5"></a>Although it should be avoided whenever possible,
+                                            <a id="17.I.4.a.5">17.I.4.a.5.</a> Although it should be avoided whenever possible,
                                             <span class="tooltip" title="Contact between opposing players that does not affect continued play.">incidental contact</span>
                                             occurring during the follow-through (after the disc is released) is not a foul.
                                             <span class="annotation">[[Remember, even if the contact were non-incidental, because it occurred after the throw was released, it cannot be deemed to have affected the specific play, and a turnover will stand.]]</span>
                                         </li>
                                         <li>
-                                            <a id="17.I.4.a.6"></a>If non-<span class="tooltip" title="Contact between opposing players that does not affect continued play.">incidental contact</span>
+                                            <a id="17.I.4.a.6">17.I.4.a.6.</a> If non-<span class="tooltip" title="Contact between opposing players that does not affect continued play.">incidental contact</span>
                                             occurs between the thrower and
                                             <span class="tooltip" title="The defensive player within ten feet of the thrower&#39;s pivot or of the thrower if no pivot has been established. If the disc is not in a player&#39;s possession, a defensive player within ten feet of a spot on the field where the disc is to be put into play is considered the marker.">marker</span>
                                             such that the thrower could call a throwing foul on the marker, the thrower may instead choose to call “contact.” Play does not stop and the marker resumes the stall count at “one.” Other than resetting the stall count, the “contact” call is resolved in the same manner as a marking violation (marker may contest the “contact” call by calling “violation,” which stops play. If the thrower calls “contact” after beginning the throwing motion and subsequently releases the disc, it is treated as if the thrower called “foul.”
                                         </li>
                                         <li>
-                                            <a id="17.I.4.a.7"></a>Any references above to a
+                                            <a id="17.I.4.a.7">17.I.4.a.7.</a> Any references above to a
                                             <span class="tooltip" title="The defensive player within ten feet of the thrower&#39;s pivot or of the thrower if no pivot has been established. If the disc is not in a player&#39;s possession, a defensive player within ten feet of a spot on the field where the disc is to be put into play is considered the marker.">marker</span>
                                             also apply to any
                                             <span class="tooltip" title="A player whose team is not in possession of the disc. A defensive player may not pick up a live disc or a disc in play or call for a pass from the thrower.">defensive player</span>
                                             within ten feet of the thrower's
                                             <span class="tooltip" title="The particular part of the body in continuous contact with a single spot on the field during a thrower&#39;s possession once the thrower has come to a stop or has attempted a throw or fake. When there is a definitive spot for putting the disc into play, the part of the body in contact with that spot is the pivot.">pivot</span>.
                                         </li>
-                                    </ol>
+                                    </ul>
                                 </li>
 
                                 <li>
-                                    <a id="17.I.4.b"></a>Receiving Fouls:
-                                    <ol>
+                                    <a id="17.I.4.b">17.I.4.b.</a> Receiving Fouls:
+                                    <ul>
                                         <li>
-                                            <a id="17.I.4.b.1"></a>If a player contacts an opponent while the disc is in the air and thereby interferes with that opponent's attempt to make a play on the disc, that player has committed a receiving foul. Some amount of
+                                            <a id="17.I.4.b.1">17.I.4.b.1.</a> If a player contacts an opponent while the disc is in the air and thereby interferes with that opponent's attempt to make a play on the disc, that player has committed a receiving foul. Some amount of
                                             <span class="tooltip" title="Contact between opposing players that does not affect continued play.">incidental contact</span>
                                             before, during, or immediately after the attempt often is unavoidable and is not a foul.
                                             <span class="annotation">[[The opponent must at least begin an attempt to make a play on the disc. The opponent's “attempt to make a play on the disc” includes any second efforts after a disc is tipped, if the disc has not become uncatchable.]]</span><span class="annotation">[[Incidental contact, by definition, is not a foul.]]</span>
                                         </li>
                                         <li>
-                                            <a id="17.I.4.b.2"></a>If <a href="https://usaultimate.org/rules/#17.C.3.b.1">17.C.3.b.1</a> or <a href="https://usaultimate.org/rules/#17.C.4.a.1">17.C.4.a.1</a>
+                                            <a id="17.I.4.b.2">17.I.4.b.2.</a> If <a href="https://usaultimate.org/rules/#17.C.3.b.1">17.C.3.b.1</a> or <a href="https://usaultimate.org/rules/#17.C.4.a.1">17.C.4.a.1</a>
                                             of the Continuation Rule applies: if the call is uncontested, the fouled player gains possession at the spot on the playing field closest to the spot of the infraction. If the foul is contested, the disc reverts to the thrower.
                                         </li>
                                         <li>
-                                            <a id="17.I.4.b.3"></a>The Principle of Verticality: All players have the right to enter the air space immediately above their torso to make a play on a thrown disc. If non-<span class="tooltip" title="Contact between opposing players that does not affect continued play.">incidental contact</span>
+                                            <a id="17.I.4.b.3">17.I.4.b.3.</a> The Principle of Verticality: All players have the right to enter the air space immediately above their torso to make a play on a thrown disc. If non-<span class="tooltip" title="Contact between opposing players that does not affect continued play.">incidental contact</span>
                                             occurs in the airspace immediately above a player before the outcome of the play is determined (e.g., before possession is gained or an incomplete pass is effected), it is a foul on the player entering the vertical space of the other player.
                                             <span class="annotation">[[If the disc is caught (or rendered uncatchable) before contact occurs, then the outcome of the play is determined already and the contact is not an infraction of this rule.]]</span>
                                         </li>
-                                        <li><a id="17.I.4.b.4"></a>Force-out Foul: If an airborne player catches the disc and is contacted by an opposing player before landing, and that contact causes the player to land out-of-bounds instead of in-bounds, or out of the end zone instead of in the end zone, it is a foul on the opposing player and the fouled player retains possession at the spot of the foul. If an uncontested force-out foul results in an in-bounds player landing outside the end zone being attacked when they would have landed in the end zone without the foul, a goal is awarded.</li>
-                                    </ol>
+                                        <li><a id="17.I.4.b.4">17.I.4.b.4.</a> Force-out Foul: If an airborne player catches the disc and is contacted by an opposing player before landing, and that contact causes the player to land out-of-bounds instead of in-bounds, or out of the end zone instead of in the end zone, it is a foul on the opposing player and the fouled player retains possession at the spot of the foul. If an uncontested force-out foul results in an in-bounds player landing outside the end zone being attacked when they would have landed in the end zone without the foul, a goal is awarded.</li>
+                                    </ul>
                                 </li>
 
                                 <li>
-                                    <a id="17.I.4.c"></a>Blocking Fouls:
-                                    <ol>
+                                    <a id="17.I.4.c">17.I.4.c.</a> Blocking Fouls:
+                                    <ul>
                                         <li>
-                                            <a id="17.I.4.c.1"></a>When the disc is in the air a player may not move in a manner solely to prevent an opponent from taking an unoccupied path to the disc and any resulting non-<span class="tooltip" title="Contact between opposing players that does not affect continued play.">incidental contact</span> is a foul on the blocking player which is treated like a receiving foul (<a href="https://usaultimate.org/rules/#17.I.4.b">17.I.4.b</a>).
+                                            <a id="17.I.4.c.1">17.I.4.c.1.</a> When the disc is in the air a player may not move in a manner solely to prevent an opponent from taking an unoccupied path to the disc and any resulting non-<span class="tooltip" title="Contact between opposing players that does not affect continued play.">incidental contact</span> is a foul on the blocking player which is treated like a receiving foul (<a href="https://usaultimate.org/rules/#17.I.4.b">17.I.4.b</a>).
                                             <span class="annotation">[[Solely. The intent of the player's movement can be partly motivated to prevent an opponent from taking an unoccupied path to the disc, so long as it is part of a general effort to make a play on the disc. Note, if a trailing player runs into a player in front of them, it is nearly always a foul on the trailing player.]]</span>
                                         </li>
                                         <li>
-                                            <a id="17.I.4.c.2"></a>A player may not take a position that is unavoidable by a moving opponent when time, distance, and line of sight are considered.
+                                            <a id="17.I.4.c.2">17.I.4.c.2.</a> A player may not take a position that is unavoidable by a moving opponent when time, distance, and line of sight are considered.
                                             <span class="annotation">[[If you are already in a position, you maintaining that position is not “taking a position.”]]</span>
                                             Non-<span class="tooltip" title="Contact between opposing players that does not affect continued play.">incidental contact</span>
                                             resulting from taking such a position is a foul on the blocking player.
                                         </li>
-                                    </ol>
+                                    </ul>
                                 </li>
 
                                 <li>
-                                    <a id="17.I.4.d"></a>Strip: If a
+                                    <a id="17.I.4.d">17.I.4.d.</a> Strip: If a
                                     <span class="tooltip" title="Non-Incidental contact: contact between opposing players (see 3.F for a definition of incidental contact). In general, the player initiating the contact has committed the foul.">foul</span>
                                     causes a player to lose
                                     <span class="tooltip" title="Sustained contact with, and control of, a non-spinning disc.">possession</span>
@@ -1887,16 +1892,16 @@
                                     <span class="annotation">[[Initiating contact with a disc in a player's possession is a foul.]]</span>
                                     <span class="annotation">[[Sustained contact with, and control of, a non-spinning disc is required to establish possession (<a href="https://usaultimate.org/rules/#3.J">3.J</a>). A player may not call a strip if they had only momentary contact with or lacked control of the disc at the time of an opponent contacting the disc because the player did not have possession.]]</span>
                                 </li>
-                            </ol>
+                            </ul>
                         </li>
-                    </ol>
+                    </ul>
                 </li>
 
                 <li>
-                    <a id="17.J"></a>Picks:
-                    <ol>
+                    <a id="17.J">17.J.</a> Picks:
+                    <ul>
                         <li>
-                            <a id="17.J.1"></a>A pick occurs whenever an
+                            <a id="17.J.1">17.J.1.</a> A pick occurs whenever an
                             <span class="tooltip" title="A player whose team is in possession of the disc.">offensive player</span>
                             moves in a manner that causes a
                             <span class="tooltip" title="A player whose team is not in possession of the disc. A defensive player may not pick up a live disc or a disc in play or call for a pass from the thrower.">defensive player</span>
@@ -1906,77 +1911,77 @@
                             to be obstructed by another player. Obstruction may result from contact with, or the need to avoid, the obstructing player. However, it is not a pick if both the offensive player being guarded and the obstructing player are making a play on the disc at the time of the obstruction.
                         </li>
                         <li>
-                            <a id="17.J.2"></a>A pick can be called only by the obstructed player and must be announced by loudly calling “pick” immediately after it occurs.
+                            <a id="17.J.2">17.J.2.</a> A pick can be called only by the obstructed player and must be announced by loudly calling “pick” immediately after it occurs.
                             <span class="annotation">[[Call the pick immediately. If you wait too long, you lose your window of opportunity to make the call.]]</span>
                         </li>
                         <li>
-                            <a id="17.J.3"></a>If play stops according to <a href="https://usaultimate.org/rules/#17.C">17.C</a>, players reposition according to <a href="https://usaultimate.org/rules/#17.C.6">17.C.6</a>.
+                            <a id="17.J.3">17.J.3.</a> If play stops according to <a href="https://usaultimate.org/rules/#17.C">17.C</a>, players reposition according to <a href="https://usaultimate.org/rules/#17.C.6">17.C.6</a>.
                             <span class="annotation">[[So if the disc is returned to the thrower, everyone resumes the locations they occupied at the earlier of the time of the throw or the time of the call.]]</span>
                             In addition, the obstructed player is then allowed to move to recover the relative position lost because of the pick.
                             <span class="annotation">[[Then the picked defender catches up the relative position lost because of the pick. If they were trailing by 9 feet, then they get to catch back up to 9 feet away, but does not get to set up right next to the <span class="tooltip" title="A player whose team is in possession of the disc.">offensive player</span>.]]</span>
                         </li>
-                        <li><a id="17.J.4"></a>During any <span class="tooltip" title="Any halting of play due to a call, discussion, or timeout that requires a check or self-check to restart play. The term play stops means a stoppage of play occurs.">stoppage of play</span>, opposing players may agree to slightly adjust their locations to avoid potential imminent picks.</li>
-                    </ol>
+                        <li><a id="17.J.4">17.J.4.</a> During any <span class="tooltip" title="Any halting of play due to a call, discussion, or timeout that requires a check or self-check to restart play. The term play stops means a stoppage of play occurs.">stoppage of play</span>, opposing players may agree to slightly adjust their locations to avoid potential imminent picks.</li>
+                    </ul>
                 </li>
 
                 <li>
-                    <a id="17.K"></a>Traveling: The thrower must establish and continually maintain a
+                    <a id="17.K">17.K.</a> Traveling: The thrower must establish and continually maintain a
                     <span class="tooltip" title="The particular part of the body in continuous contact with a single spot on the field during a thrower&#39;s possession once the thrower has come to a stop or has attempted a throw or fake. When there is a definitive spot for putting the disc into play, the part of the body in contact with that spot is the pivot.">pivot</span>
                     at the appropriate spot on the field until the throw is released. Failure to do so is a travel and is resolved according to <a href="https://usaultimate.org/rules/#17.K.3">17.K.3</a>, below.
                     <span class="annotation">[[Resolved according to <a href="https://usaultimate.org/rules/#17.K.3">17.K.3</a> only if the travel is called, otherwise play continues uninterrupted.]][[Remember that according to <a href="https://usaultimate.org/rules/#17.A">17.A</a>, a player must perceive that this infraction has occurred in order to make a call. In most cases, it is unreasonable for a marker to recognize an infraction concerning a small toe-drag during the release of a throw since this would require the marker to simultaneously perceive both the toe-drag and the release. To ensure accuracy, defenders should err toward allowing play to continue if the drag causing the travel is less than two inches.]] [[In addition, remember that a player must only make a call where the infraction is significant enough to affect play (<a href="https://usaultimate.org/rules/#2.D.2">2.D.2</a>).]]</span>
-                    <ol>
+                    <ul>
                         <li>
-                            <a id="17.K.1"></a>In addition, each of the following is a travel:
-                            <ol>
+                            <a id="17.K.1">17.K.1.</a> In addition, each of the following is a travel:
+                            <ul>
                                 <li>
-                                    <a id="17.K.1.a"></a>A player catches the disc and either speeds up, changes direction or does not stop as quickly as possible before establishing a
+                                    <a id="17.K.1.a">17.K.1.a.</a> A player catches the disc and either speeds up, changes direction or does not stop as quickly as possible before establishing a
                                     <span class="tooltip" title="The particular part of the body in continuous contact with a single spot on the field during a thrower&#39;s possession once the thrower has come to a stop or has attempted a throw or fake. When there is a definitive spot for putting the disc into play, the part of the body in contact with that spot is the pivot.">pivot</span>
                                     (<a href="https://usaultimate.org/rules/#16.B">16.B</a>).
                                 </li>
                                 <li>
-                                    <a id="17.K.1.b"></a>A player receives a pass while running or jumping, and releases a pass after the third additional
+                                    <a id="17.K.1.b">17.K.1.b.</a> A player receives a pass while running or jumping, and releases a pass after the third additional
                                     <span class="tooltip" title="All player contact with the ground directly related to a specific event or maneuver (e.g., jumping, diving, leaning or falling), including landing or recovering after being off-balance. Items on the ground are considered part of the ground.">ground contact</span>
                                     and before establishing a
                                     <span class="tooltip" title="The particular part of the body in continuous contact with a single spot on the field during a thrower&#39;s possession once the thrower has come to a stop or has attempted a throw or fake. When there is a definitive spot for putting the disc into play, the part of the body in contact with that spot is the pivot.">pivot</span>
                                     (<a href="https://usaultimate.org/rules/#16.C">16.C</a>).
                                 </li>
                                 <li>
-                                    <a id="17.K.1.c"></a>Purposeful bobbling (including tipping, delaying, guiding, brushing, or the like) to oneself in order to advance the disc in any direction from where it initially was contacted (<a href="https://usaultimate.org/rules/#16.A">16.A</a>).
-                                    <ol>
-                                        <li><a id="17.K.1.c.1"></a>If a defender commits this infraction and the result of the play is a turnover, the defender retains possession at the initial spot of the travel.</li>
-                                    </ol>
+                                    <a id="17.K.1.c">17.K.1.c.</a> Purposeful bobbling (including tipping, delaying, guiding, brushing, or the like) to oneself in order to advance the disc in any direction from where it initially was contacted (<a href="https://usaultimate.org/rules/#16.A">16.A</a>).
+                                    <ul>
+                                        <li><a id="17.K.1.c.1">17.K.1.c.1.</a> If a defender commits this infraction and the result of the play is a turnover, the defender retains possession at the initial spot of the travel.</li>
+                                    </ul>
                                 </li>
 
-                                <li><a id="17.K.1.d"></a>The thrower fails to touch the disc to the ground when required (<a href="https://usaultimate.org/rules/#14.B">14.B</a>).</li>
-                            </ol>
+                                <li><a id="17.K.1.d">17.K.1.d.</a> The thrower fails to touch the disc to the ground when required (<a href="https://usaultimate.org/rules/#14.B">14.B</a>).</li>
+                            </ul>
                         </li>
 
                         <li>
-                            <a id="17.K.2"></a>Exceptions:
-                            <ol>
+                            <a id="17.K.2">17.K.2.</a> Exceptions:
+                            <ul>
                                 <li>
-                                    <a id="17.K.2.a"></a>If a non-standing player loses contact with the
+                                    <a id="17.K.2.a">17.K.2.a.</a> If a non-standing player loses contact with the
                                     <span class="tooltip" title="The particular part of the body in continuous contact with a single spot on the field during a thrower&#39;s possession once the thrower has come to a stop or has attempted a throw or fake. When there is a definitive spot for putting the disc into play, the part of the body in contact with that spot is the pivot.">pivot</span>
                                     spot in order to stand up, it is not a travel, provided the new pivot is established at the same location.
                                 </li>
                                 <li>
-                                    <a id="17.K.2.b"></a>It is not a travel if a player catches the disc and releases a pass before three additional points of
+                                    <a id="17.K.2.b">17.K.2.b.</a> It is not a travel if a player catches the disc and releases a pass before three additional points of
                                     <span class="tooltip" title="All player contact with the ground directly related to a specific event or maneuver (e.g., jumping, diving, leaning or falling), including landing or recovering after being off-balance. Items on the ground are considered part of the ground.">ground contact</span>
                                     (<a href="https://usaultimate.org/rules/#16.C">16.C</a>).
                                 </li>
-                                <li><a id="17.K.2.c"></a>If play stops, the thrower may reset the <span class="tooltip" title="The particular part of the body in continuous contact with a single spot on the field during a thrower&#39;s possession once the thrower has come to a stop or has attempted a throw or fake. When there is a definitive spot for putting the disc into play, the part of the body in contact with that spot is the pivot.">pivot</span>.</li>
-                            </ol>
+                                <li><a id="17.K.2.c">17.K.2.c.</a> If play stops, the thrower may reset the <span class="tooltip" title="The particular part of the body in continuous contact with a single spot on the field during a thrower&#39;s possession once the thrower has come to a stop or has attempted a throw or fake. When there is a definitive spot for putting the disc into play, the part of the body in contact with that spot is the pivot.">pivot</span>.</li>
+                            </ul>
                         </li>
 
                         <li>
-                            <a id="17.K.3"></a>Resolutions:
-                            <ol>
+                            <a id="17.K.3">17.K.3.</a> Resolutions:
+                            <ul>
                                 <li>
-                                    <a id="17.K.3.a"></a>If the travel occurs and a pass is thrown:
-                                    <ol>
-                                        <li><a id="17.K.3.a.1"></a>If the pass is incomplete, play continues uninterrupted (as per the Continuation Rule, <a href="https://usaultimate.org/rules/#17.C.4.b">17.C.4.b</a>).</li>
+                                    <a id="17.K.3.a">17.K.3.a.</a> If the travel occurs and a pass is thrown:
+                                    <ul>
+                                        <li><a id="17.K.3.a.1">17.K.3.a.1.</a> If the pass is incomplete, play continues uninterrupted (as per the Continuation Rule, <a href="https://usaultimate.org/rules/#17.C.4.b">17.C.4.b</a>).</li>
                                         <li>
-                                            <a id="17.K.3.a.2"></a>If the pass is complete, play stops and the disc is returned to the thrower where the travel occurred (as per the Continuation Rule, <a href="https://usaultimate.org/rules/#17.C.4.a.1">17.C.4.a.1</a>). Play restarts with a check.
+                                            <a id="17.K.3.a.2">17.K.3.a.2.</a> If the pass is complete, play stops and the disc is returned to the thrower where the travel occurred (as per the Continuation Rule, <a href="https://usaultimate.org/rules/#17.C.4.a.1">17.C.4.a.1</a>). Play restarts with a check.
                                             <span class="annotation"
                                                 >[[The spot where the travel occurred is the spot on the field where the thrower's
                                                 <span class="tooltip" title="The particular part of the body in continuous contact with a single spot on the field during a thrower&#39;s possession once the thrower has come to a stop or has attempted a throw or fake. When there is a definitive spot for putting the disc into play, the part of the body in contact with that spot is the pivot.">pivot</span>
@@ -1987,18 +1992,18 @@
                                                 <span class="tooltip" title="A disc is in play when players are allowed to move and play may proceed without the defense&#39;s acknowledgment. An in-bounds disc in the central zone is in play. The disc is subject to a turnover. If no player has possession of a disc in play, any offensive player may become the thrower by taking possession of the disc (14.A). Once a player has possession of the disc, they must establish a pivot at the spot of the disc 14.A.2) prior to attempting a pass (17.K).">in play</span>. At this point, the stall count may resume.]]</span
                                             >
                                         </li>
-                                    </ol>
+                                    </ul>
                                 </li>
 
                                 <li>
-                                    <a id="17.K.3.b"></a>If the travel occurs and no pass has been attempted:
-                                    <ol>
+                                    <a id="17.K.3.b">17.K.3.b.</a> If the travel occurs and no pass has been attempted:
+                                    <ul>
                                         <li>
-                                            <a id="17.K.3.b.1"></a>Play does not stop. The defense (typically the <span class="tooltip" title="The defensive player within ten feet of the thrower&#39;s pivot or of the thrower if no pivot has been established. If the disc is not in a player&#39;s possession, a defensive player within ten feet of a spot on the field where the disc is to be put into play is considered the marker.">marker</span>) points to the spot where the travel occurred, and the thrower returns to that spot without delay. The thrower must touch the disc to the ground before attempting a legal pass.
+                                            <a id="17.K.3.b.1">17.K.3.b.1.</a> Play does not stop. The defense (typically the <span class="tooltip" title="The defensive player within ten feet of the thrower&#39;s pivot or of the thrower if no pivot has been established. If the disc is not in a player&#39;s possession, a defensive player within ten feet of a spot on the field where the disc is to be put into play is considered the marker.">marker</span>) points to the spot where the travel occurred, and the thrower returns to that spot without delay. The thrower must touch the disc to the ground before attempting a legal pass.
                                             <span class="annotation">[[Play does not stop, but the disc is <span class="tooltip" title="A disc is live when players are allowed to move and the disc is subject to a turnover, but the thrower cannot make a legal pass (e.g., walking the disc to the spot where it is to be put into play). For a live disc to be put into play, the thrower must (1) establish a pivot at the appropriate spot on the field, and (2) touch the disc to the ground (14.B).">live</span>, so it is still subject to a turnover (for example if the thrower drops it).]]</span>
                                         </li>
                                         <li>
-                                            <a id="17.K.3.b.2"></a>The stall count is paused until the thrower sets a
+                                            <a id="17.K.3.b.2">17.K.3.b.2.</a> The stall count is paused until the thrower sets a
                                             <span class="tooltip" title="The particular part of the body in continuous contact with a single spot on the field during a thrower&#39;s possession once the thrower has come to a stop or has attempted a throw or fake. When there is a definitive spot for putting the disc into play, the part of the body in contact with that spot is the pivot.">pivot</span>
                                             where the travel occurred. The
                                             <span class="tooltip" title="The defensive player within ten feet of the thrower&#39;s pivot or of the thrower if no pivot has been established. If the disc is not in a player&#39;s possession, a defensive player within ten feet of a spot on the field where the disc is to be put into play is considered the marker.">marker</span>
@@ -2006,102 +2011,102 @@
                                             <span class="annotation">[[The marker must initiate a stall count with the word “stalling,” but resuming the count does not require the marker to say “stalling” again.]]</span>
                                         </li>
                                         <li>
-                                            <a id="17.K.3.b.3"></a>If the thrower wishes to contest the travel call, they announce “violation” and play stops. Upon checking the disc in, the stall count resumes at the count reached plus 1, or 6 if over 5 (<a href="https://usaultimate.org/rules/#15.A.5.a.3">15.A.5.a.3</a>).
+                                            <a id="17.K.3.b.3">17.K.3.b.3.</a> If the thrower wishes to contest the travel call, they announce “violation” and play stops. Upon checking the disc in, the stall count resumes at the count reached plus 1, or 6 if over 5 (<a href="https://usaultimate.org/rules/#15.A.5.a.3">15.A.5.a.3</a>).
                                             <span class="annotation"
                                                 >[[If the defense does not indicate to the thrower where the travel occurred, or the thrower wishes to contest the location of an indicated spot, the thrower should announce “violation”, stopping play, and explain that the spot was incorrectly/not indicated. After setting their
                                                 <span class="tooltip" title="The particular part of the body in continuous contact with a single spot on the field during a thrower&#39;s possession once the thrower has come to a stop or has attempted a throw or fake. When there is a definitive spot for putting the disc into play, the part of the body in contact with that spot is the pivot.">pivot</span>
                                                 in the correct spot, and checking the disc in, the stall count resumes at the count reached plus 1, or 6 if over 5 (<a href="https://usaultimate.org/rules/#15.A.5.a.3">15.A.5.a.3</a>).]]</span
                                             >
                                         </li>
-                                    </ol>
+                                    </ul>
                                 </li>
-                            </ol>
+                            </ul>
                         </li>
-                    </ol>
+                    </ul>
                 </li>
 
                 <li>
-                    <a id="17.L"></a>A player's ability to catch or make a play on the disc is not considered to be “affected” because that player stopped, slowed down, or otherwise ceased to continue playing because a call was made by another player. Players are encouraged to make every effort to continue playing until play actually stops.
+                    <a id="17.L">17.L.</a> A player's ability to catch or make a play on the disc is not considered to be “affected” because that player stopped, slowed down, or otherwise ceased to continue playing because a call was made by another player. Players are encouraged to make every effort to continue playing until play actually stops.
                     <span class="annotation">[[When a player determines whether an infraction affected the play (<a href="https://usaultimate.org/rules/#17.C.5">17.C.5</a>), this is very important to recognize.]]</span>
                 </li>
-            </ol>
+            </ul>
         </li>
 
         <li>
-            <a id="18"></a>Positioning
-            <ol>
-                <li><a id="18.A"></a>Each player is entitled to occupy any position on the field not occupied by an opposing player, unless specifically overridden elsewhere, provided that no personal contact is caused in taking such a position.</li>
+            <a id="18">18.</a> Positioning
+            <ul>
+                <li><a id="18.A">18.A.</a> Each player is entitled to occupy any position on the field not occupied by an opposing player, unless specifically overridden elsewhere, provided that no personal contact is caused in taking such a position.</li>
                 <li>
-                    <a id="18.B"></a>A player who jumps is entitled to land at the take-off spot without hindrance by opponents. That player also is entitled to land at another spot, provided that the landing spot, and the direct path between the take-off and landing spots, were not already occupied at the time of take-off.
+                    <a id="18.B">18.B.</a> A player who jumps is entitled to land at the take-off spot without hindrance by opponents. That player also is entitled to land at another spot, provided that the landing spot, and the direct path between the take-off and landing spots, were not already occupied at the time of take-off.
                     <span class="annotation">[[This does not trump a player's responsibility to make reasonable efforts to avoid contact and to not commit a blocking foul. If you commit a blocking foul, the fact that you jumped to the spot instead of running does not negate the foul.]]</span>
                 </li>
-                <li><a id="18.C"></a>Players may not use their extended arms or legs to obstruct the movement of an opponent. <span class="annotation">[[A player's arms and legs are not considered “extended” during normal running and jumping.]]</span></li>
-            </ol>
+                <li><a id="18.C">18.C.</a> Players may not use their extended arms or legs to obstruct the movement of an opponent. <span class="annotation">[[A player's arms and legs are not considered “extended” during normal running and jumping.]]</span></li>
+            </ul>
         </li>
 
         <li>
-            <a id="19"></a>Observers
-            <ol>
+            <a id="19">19.</a> Observers
+            <ul>
                 <li>
-                    <a id="19.A"></a><span class="tooltip" title="Observers are non-player game officials whose job is to support the players in implementing a safe, fair, and efficient game. Observers carefully watch the action of the game, assist with communication, help uphold self-officiating and the Spirit of the Game, assist with resolving calls as needed, and perform other duties as described in Section 19">Observers</span>
+                    <a id="19.A">19.A.</a> <span class="tooltip" title="Observers are non-player game officials whose job is to support the players in implementing a safe, fair, and efficient game. Observers carefully watch the action of the game, assist with communication, help uphold self-officiating and the Spirit of the Game, assist with resolving calls as needed, and perform other duties as described in Section 19">Observers</span>
                     may be used if desired by the
                     <span class="tooltip" title="A team member, who is eligible to participate in the game, and has been designated to represent the team in decision-making on behalf of the team before, during, and after a game.">captains</span>
                     or the event organizer.
                 </li>
                 <li>
-                    <a id="19.B"></a><span class="tooltip" title="Observers are non-player game officials whose job is to support the players in implementing a safe, fair, and efficient game. Observers carefully watch the action of the game, assist with communication, help uphold self-officiating and the Spirit of the Game, assist with resolving calls as needed, and perform other duties as described in Section 19">Observers</span>
+                    <a id="19.B">19.B.</a> <span class="tooltip" title="Observers are non-player game officials whose job is to support the players in implementing a safe, fair, and efficient game. Observers carefully watch the action of the game, assist with communication, help uphold self-officiating and the Spirit of the Game, assist with resolving calls as needed, and perform other duties as described in Section 19">Observers</span>
                     may perform any or all of the following duties:
-                    <ol>
-                        <li><a id="19.B.1"></a>Track time limits and announce associated warnings and expirations.</li>
+                    <ul>
+                        <li><a id="19.B.1">19.B.1.</a> Track time limits and announce associated warnings and expirations.</li>
                         <li>
-                            <a id="19.B.2"></a>Resolve player disputes.
-                            <ol>
+                            <a id="19.B.2">19.B.2.</a> Resolve player disputes.
+                            <ul>
                                 <li>
-                                    <a id="19.B.2.a"></a>Any player directly involved in a dispute may request
+                                    <a id="19.B.2.a">19.B.2.a.</a> Any player directly involved in a dispute may request
                                     <span class="tooltip" title="Observers are non-player game officials whose job is to support the players in implementing a safe, fair, and efficient game. Observers carefully watch the action of the game, assist with communication, help uphold self-officiating and the Spirit of the Game, assist with resolving calls as needed, and perform other duties as described in Section 19">observer</span>
                                     resolution.
                                 </li>
                                 <li>
-                                    <a id="19.B.2.b"></a>An
+                                    <a id="19.B.2.b">19.B.2.b.</a> An
                                     <span class="tooltip" title="Observers are non-player game officials whose job is to support the players in implementing a safe, fair, and efficient game. Observers carefully watch the action of the game, assist with communication, help uphold self-officiating and the Spirit of the Game, assist with resolving calls as needed, and perform other duties as described in Section 19">observer</span>
                                     may resolve a dispute without request from the players involved if they cannot resolve it in a timely manner.
                                 </li>
                                 <li>
-                                    <a id="19.B.2.c"></a>If an
+                                    <a id="19.B.2.c">19.B.2.c.</a> If an
                                     <span class="tooltip" title="Observers are non-player game officials whose job is to support the players in implementing a safe, fair, and efficient game. Observers carefully watch the action of the game, assist with communication, help uphold self-officiating and the Spirit of the Game, assist with resolving calls as needed, and perform other duties as described in Section 19">observer</span>
                                     is involved in resolving a dispute, play restarts with a check.
                                 </li>
-                            </ol>
+                            </ul>
                         </li>
 
-                        <li><a id="19.B.3"></a>Censure or eject players for Spirit of the Game infractions. This includes assigning responsibility for game delays to a specific player.</li>
-                        <li><a id="19.B.4"></a>Render opinions on other on-field events (e.g., line and offside calls), as determined in advance by the event organizer.</li>
-                    </ol>
+                        <li><a id="19.B.3">19.B.3.</a> Censure or eject players for Spirit of the Game infractions. This includes assigning responsibility for game delays to a specific player.</li>
+                        <li><a id="19.B.4">19.B.4.</a> Render opinions on other on-field events (e.g., line and offside calls), as determined in advance by the event organizer.</li>
+                    </ul>
                 </li>
 
-                <li><a id="19.C"></a>By playing under <span class="tooltip" title="Observers are non-player game officials whose job is to support the players in implementing a safe, fair, and efficient game. Observers carefully watch the action of the game, assist with communication, help uphold self-officiating and the Spirit of the Game, assist with resolving calls as needed, and perform other duties as described in Section 19">observers</span>, the players agree to abide by the observers' decisions.</li>
+                <li><a id="19.C">19.C.</a> By playing under <span class="tooltip" title="Observers are non-player game officials whose job is to support the players in implementing a safe, fair, and efficient game. Observers carefully watch the action of the game, assist with communication, help uphold self-officiating and the Spirit of the Game, assist with resolving calls as needed, and perform other duties as described in Section 19">observers</span>, the players agree to abide by the observers' decisions.</li>
                 <li>
-                    <a id="19.D"></a>Players may overrule an
+                    <a id="19.D">19.D.</a> Players may overrule an
                     <span class="tooltip" title="Observers are non-player game officials whose job is to support the players in implementing a safe, fair, and efficient game. Observers carefully watch the action of the game, assist with communication, help uphold self-officiating and the Spirit of the Game, assist with resolving calls as needed, and perform other duties as described in Section 19">observer's</span>
                     active ruling, provided it is to their team's detriment. Players may also decline enforcement of a yardage penalty assessed through the misconduct system. Observers may deny the declination if they feel the teams are trying to circumvent mandatory tournament rules, guidelines, or player safety.
                     <span class="annotation">[[If, for example, teams are trying to maintain proper sideline buffer zones, but a team is assessed a penalty after a third technical, an opposing team may decide to decline the yardage penalty as they do not want to gain an advantage in the game for this reason. Observers should accept this declination. However, if teams mutually agree to ignore the sideline technicals and players are willfully not maintaining proper safety buffers, this would be an example of when an observer should not allow the declining of the yardage penalty. Proper communication between observers and teams should alleviate any concerns.]]</span>
                 </li>
-            </ol>
+            </ul>
         </li>
 
         <li>
-            <a id="20"></a>Etiquette
-            <ol>
-                <li><a id="20.A"></a>If an infraction is committed and not called, the player committing the infraction should inform the infracted player or team of the infraction.</li>
+            <a id="20">20.</a> Etiquette
+            <ul>
+                <li><a id="20.A">20.A.</a> If an infraction is committed and not called, the player committing the infraction should inform the infracted player or team of the infraction.</li>
                 <li>
-                    <a id="20.B"></a>It is the responsibility of all players to avoid any delay when starting, restarting, or continuing play. This includes standing over the disc or taking more time than reasonably necessary to put the disc into play.
+                    <a id="20.B">20.B.</a> It is the responsibility of all players to avoid any delay when starting, restarting, or continuing play. This includes standing over the disc or taking more time than reasonably necessary to put the disc into play.
                     <span class="annotation">[[This includes standing back from the disc, wandering around to gain more time, etc. Pretending not to delay while delaying is still delaying.]]</span>
                 </li>
-                <li><a id="20.C"></a>On a <span class="tooltip" title="Any halting of play due to a call, discussion, or timeout that requires a check or self-check to restart play. The term play stops means a stoppage of play occurs.">stoppage of play</span>, if it is ever unclear which of a team's members are the current players or where they are on or off the field, they should identify themselves when the opposing team requests.</li>
-                <li><a id="20.D"></a>If a dispute arises on the field, play stops and is restarted with a check when the matter is resolved.</li>
-                <li><a id="20.E"></a>If a novice player commits an infraction out of sincere ignorance of the rules, it should be common practice to stop play and explain the infraction.</li>
+                <li><a id="20.C">20.C.</a> On a <span class="tooltip" title="Any halting of play due to a call, discussion, or timeout that requires a check or self-check to restart play. The term play stops means a stoppage of play occurs.">stoppage of play</span>, if it is ever unclear which of a team's members are the current players or where they are on or off the field, they should identify themselves when the opposing team requests.</li>
+                <li><a id="20.D">20.D.</a> If a dispute arises on the field, play stops and is restarted with a check when the matter is resolved.</li>
+                <li><a id="20.E">20.E.</a> If a novice player commits an infraction out of sincere ignorance of the rules, it should be common practice to stop play and explain the infraction.</li>
                 <li>
-                    <a id="20.F"></a>When a call is made, throwers must stop play by visibly or audibly communicating the stoppage as soon as they are aware of the call and all players should echo calls on the field.
+                    <a id="20.F">20.F.</a> When a call is made, throwers must stop play by visibly or audibly communicating the stoppage as soon as they are aware of the call and all players should echo calls on the field.
                     <span class="annotation"
                         >[[If the
                         <span class="tooltip" title="The defensive player within ten feet of the thrower&#39;s pivot or of the thrower if no pivot has been established. If the disc is not in a player&#39;s possession, a defensive player within ten feet of a spot on the field where the disc is to be put into play is considered the marker.">marker</span>
@@ -2110,14 +2115,14 @@
                         will come back to the thrower (<a href="https://usaultimate.org/rules/#17.C.4.a.1">17.C.4.a.1</a>).]]</span
                     >
                 </li>
-                <li><a id="20.G"></a>In addition to the assumption that players will not intentionally violate the rules, players are similarly expected to make every effort to avoid violating them.</li>
-            </ol>
+                <li><a id="20.G">20.G.</a> In addition to the assumption that players will not intentionally violate the rules, players are similarly expected to make every effort to avoid violating them.</li>
+            </ul>
         </li>
-    </ol>
+    </ul>
 
-    <ol class="appendices">
+    <ul class="main-rules">
         <li>
-            <a id="appendix_a"></a>Appendix A: Field Diagram
+            <a id="appendix_a">Appendix A:</a> Field Diagram
             <div class="plain">
                 <table class="fieldDiagram">
                     <tbody>
@@ -2142,252 +2147,252 @@
             </div>
         </li>
         <li>
-            <a id="appendix_b"></a>Appendix B: Misconduct System
+            <a id="appendix_b">Appendix B:</a> Misconduct System
             <div class="rulesBody plain">
                 This appendix describes the system for handling misconduct within a game that is using
                 <span class="tooltip" title="Observers are non-player game officials whose job is to support the players in implementing a safe, fair, and efficient game. Observers carefully watch the action of the game, assist with communication, help uphold self-officiating and the Spirit of the Game, assist with resolving calls as needed, and perform other duties as described in Section 19">observers</span>. For games without observers, behavior expectations and related procedures are described in <a href="https://usaultimate.org/rules/#2">Section 2 (Spirit of the Game)</a>. Additional mechanisms for handling misconduct at the event level or beyond are described in the USA Ultimate Conduct Policy. The “Event Disciplinary Authority” (EDA) as referred to in this Appendix means any tournament director, Tournament Rules Group, certified observer, Sectional or Regional Coordinator, State Youth Coordinator, Regional Youth Director, National Director, member of the USA Ultimate
                 Administration performing their duties in some specific capacity, officer or agent of USA Ultimate, or some other USA Ultimate-appointed individual or group charged with decision-making regarding conduct pertaining to a specific USA Ultimate event or program in progress.
             </div>
-            <ol>
+            <ul>
                 <li>
-                    <a id="B1"></a>Components of the Misconduct System
+                    <a id="B1">B1.</a> Components of the Misconduct System
 
-                    <ol>
+                    <ul>
                         <li>
-                            <a id="B1.A"></a>Technical Foul
-                            <ol>
-                                <li><a id="B1.A.1"></a>A Technical Foul can be assessed against a team for minor conduct violations that do not affect the competitiveness of the game.</li>
-                                <li><a id="B1.A.2"></a>The first two Technical Fouls issued to a team are warnings with no associated penalty.</li>
-                                <li><a id="B1.A.3"></a>A third or subsequent Technical Fouls for a team in a single game results in a Misconduct Penalty against that team.</li>
-                                <li><a id="B1.A.4"></a>There is no limit to the number of Technical Fouls or Misconduct Penalties a team can accrue during a game.</li>
-                                <li><a id="B1.A.5"></a>Technical Fouls do not carry over beyond the game in which they are issued.</li>
-                            </ol>
+                            <a id="B1.A">B1.A.</a> Technical Foul
+                            <ul>
+                                <li><a id="B1.A.1">B1.A.1.</a> A Technical Foul can be assessed against a team for minor conduct violations that do not affect the competitiveness of the game.</li>
+                                <li><a id="B1.A.2">B1.A.2.</a> The first two Technical Fouls issued to a team are warnings with no associated penalty.</li>
+                                <li><a id="B1.A.3">B1.A.3.</a> A third or subsequent Technical Fouls for a team in a single game results in a Misconduct Penalty against that team.</li>
+                                <li><a id="B1.A.4">B1.A.4.</a> There is no limit to the number of Technical Fouls or Misconduct Penalties a team can accrue during a game.</li>
+                                <li><a id="B1.A.5">B1.A.5.</a> Technical Fouls do not carry over beyond the game in which they are issued.</li>
+                            </ul>
                         </li>
 
                         <li>
-                            <a id="B1.B"></a>Team Misconduct Foul (Blue Card)
-                            <ol>
+                            <a id="B1.B">B1.B.</a> Team Misconduct Foul (Blue Card)
+                            <ul>
                                 <li>
-                                    <a id="B1.B.1"></a>A Team Misconduct Foul (TMF) can be assessed against a team for conduct that violates Spirit of the Game by any
+                                    <a id="B1.B.1">B1.B.1.</a> A Team Misconduct Foul (TMF) can be assessed against a team for conduct that violates Spirit of the Game by any
                                     <span class="tooltip" title="Any person designated by the team, to the event organizer, to be officially associated with the team, per the rules established by the event organizer.">team member</span>
                                     or spectators considered as partisans for the team.
                                 </li>
                                 <li>
-                                    <a id="B1.B.2"></a>The TMF can be assessed regardless of whether the infracted team makes any call, although teams are encouraged to make violation calls in order to directly communicate about issues and minimize the need for
+                                    <a id="B1.B.2">B1.B.2.</a> The TMF can be assessed regardless of whether the infracted team makes any call, although teams are encouraged to make violation calls in order to directly communicate about issues and minimize the need for
                                     <span class="tooltip" title="Observers are non-player game officials whose job is to support the players in implementing a safe, fair, and efficient game. Observers carefully watch the action of the game, assist with communication, help uphold self-officiating and the Spirit of the Game, assist with resolving calls as needed, and perform other duties as described in Section 19">observers</span>
                                     to issue TMFs without a call.
                                 </li>
-                                <li><a id="B1.B.3"></a>The first two TMFs issued to a team are warnings with no associated penalty.</li>
-                                <li><a id="B1.B.4"></a>A third or subsequent TMF for a team in a single game results in a Misconduct Penalty against that team.</li>
-                                <li><a id="B1.B.5"></a>There is no limit to the number of TMFs or Misconduct Penalties a team can accrue during a game.</li>
-                                <li><a id="B1.B.6"></a>TMFs do not carry over beyond the game in which they are issued.</li>
-                            </ol>
+                                <li><a id="B1.B.3">B1.B.3.</a> The first two TMFs issued to a team are warnings with no associated penalty.</li>
+                                <li><a id="B1.B.4">B1.B.4.</a> A third or subsequent TMF for a team in a single game results in a Misconduct Penalty against that team.</li>
+                                <li><a id="B1.B.5">B1.B.5.</a> There is no limit to the number of TMFs or Misconduct Penalties a team can accrue during a game.</li>
+                                <li><a id="B1.B.6">B1.B.6.</a> TMFs do not carry over beyond the game in which they are issued.</li>
+                            </ul>
                         </li>
 
                         <li>
-                            <a id="B1.C"></a>Personal Misconduct Foul (Yellow Card)
-                            <ol>
+                            <a id="B1.C">B1.C.</a> Personal Misconduct Foul (Yellow Card)
+                            <ul>
                                 <li>
-                                    <a id="B1.C.1"></a>A Personal Misconduct Foul (PMF) can be assessed against a specific
+                                    <a id="B1.C.1">B1.C.1.</a> A Personal Misconduct Foul (PMF) can be assessed against a specific
                                     <span class="tooltip" title="Any person designated by the team, to the event organizer, to be officially associated with the team, per the rules established by the event organizer.">team member</span>
                                     for particularly egregious conduct or a pattern of such behavior.
                                 </li>
-                                <li><a id="B1.C.2"></a>A PMF is a formal warning for unacceptable behavior and puts the team member on notice that any further such actions will result in ejection from the game.</li>
+                                <li><a id="B1.C.2">B1.C.2.</a> A PMF is a formal warning for unacceptable behavior and puts the team member on notice that any further such actions will result in ejection from the game.</li>
                                 <li>
-                                    <a id="B1.C.3"></a>A
+                                    <a id="B1.C.3">B1.C.3.</a> A
                                     <span class="tooltip" title="Any person designated by the team, to the event organizer, to be officially associated with the team, per the rules established by the event organizer.">team member</span>
                                     who receives a second PMF during a single game is ejected for the remainder of that game. If this occurs in the second half of the game, the ejection remains in effect for the first half of the team's next game.
                                 </li>
                                 <li>
-                                    <a id="B1.C.4"></a>A
+                                    <a id="B1.C.4">B1.C.4.</a> A
                                     <span class="tooltip" title="Any person designated by the team, to the event organizer, to be officially associated with the team, per the rules established by the event organizer.">team member</span>
                                     who receives three PMFs during a tournament is suspended for the remainder of the tournament.
                                 </li>
-                                <li><a id="B1.C.5"></a>Assessment of a PMF is non-reviewable for the duration of the game, although it may be appealed to the EDA after the game.</li>
-                                <li><a id="B1.C.6"></a>One TMF is automatically assessed against a team whenever one of its members receives a PMF.</li>
-                            </ol>
+                                <li><a id="B1.C.5">B1.C.5.</a> Assessment of a PMF is non-reviewable for the duration of the game, although it may be appealed to the EDA after the game.</li>
+                                <li><a id="B1.C.6">B1.C.6.</a> One TMF is automatically assessed against a team whenever one of its members receives a PMF.</li>
+                            </ul>
                         </li>
 
                         <li>
-                            <a id="B1.D"></a>Ejection (Red Card)
-                            <ol>
+                            <a id="B1.D">B1.D.</a> Ejection (Red Card)
+                            <ul>
                                 <li>
-                                    <a id="B1.D.1"></a>A
+                                    <a id="B1.D.1">B1.D.1.</a> A
                                     <span class="tooltip" title="Any person designated by the team, to the event organizer, to be officially associated with the team, per the rules established by the event organizer.">team member</span>
                                     may be ejected from a game for particularly egregious conduct.
                                 </li>
                                 <li>
-                                    <a id="B1.D.2"></a>No formal or informal warning is necessary before a
+                                    <a id="B1.D.2">B1.D.2.</a> No formal or informal warning is necessary before a
                                     <span class="tooltip" title="Any person designated by the team, to the event organizer, to be officially associated with the team, per the rules established by the event organizer.">team member</span>
                                     is ejected, and an ejection need not be preceded by a TMF or PMF.
                                 </li>
                                 <li>
-                                    <a id="B1.D.3"></a>If an ejection occurs during the second half of the game, the ejection remains in effect for the first half of the
+                                    <a id="B1.D.3">B1.D.3.</a> If an ejection occurs during the second half of the game, the ejection remains in effect for the first half of the
                                     <span class="tooltip" title="Any person designated by the team, to the event organizer, to be officially associated with the team, per the rules established by the event organizer.">team member's</span>
                                     team's next game.
                                 </li>
                                 <li>
-                                    <a id="B1.D.4"></a>If a
+                                    <a id="B1.D.4">B1.D.4.</a> If a
                                     <span class="tooltip" title="Any person designated by the team, to the event organizer, to be officially associated with the team, per the rules established by the event organizer.">team member</span>
                                     receives more than one ejection in a tournament, that
                                     <span class="tooltip" title="Any person designated by the team, to the event organizer, to be officially associated with the team, per the rules established by the event organizer.">team member</span>
                                     is suspended for the rest of the tournament, and a formal complaint may be filed with USAU.
                                 </li>
-                                <li><a id="B1.D.5"></a>An ejection is non-reviewable for the duration of the game, although it may be appealed to the EDA after the game.</li>
+                                <li><a id="B1.D.5">B1.D.5.</a> An ejection is non-reviewable for the duration of the game, although it may be appealed to the EDA after the game.</li>
                                 <li>
-                                    <a id="B1.D.6"></a>One TMF is automatically assessed against a team whenever one of its
+                                    <a id="B1.D.6">B1.D.6.</a> One TMF is automatically assessed against a team whenever one of its
                                     <span class="tooltip" title="Any person designated by the team, to the event organizer, to be officially associated with the team, per the rules established by the event organizer.">members</span>
                                     is ejected.
                                 </li>
-                            </ol>
+                            </ul>
                         </li>
 
                         <li>
-                            <a id="B1.E"></a>Game Forfeiture
-                            <ol>
+                            <a id="B1.E">B1.E.</a> Game Forfeiture
+                            <ul>
                                 <li>
-                                    <a id="B1.E.1"></a>If five PMFs are assessed against
+                                    <a id="B1.E.1">B1.E.1.</a> If five PMFs are assessed against
                                     <span class="tooltip" title="Any person designated by the team, to the event organizer, to be officially associated with the team, per the rules established by the event organizer.">team members</span>
                                     on a single team during a game, that team forfeits the game. For this purpose, an ejection is equivalent to two PMFs. For example, if three or more players on a single team are ejected, that team forfeits the game.
                                 </li>
-                                <li><a id="B1.E.2"></a>If the situation arises where both teams would be required to forfeit the game due to multiple player ejections, the EDA determines the appropriate outcome based on competition considerations.</li>
-                            </ol>
+                                <li><a id="B1.E.2">B1.E.2.</a> If the situation arises where both teams would be required to forfeit the game due to multiple player ejections, the EDA determines the appropriate outcome based on competition considerations.</li>
+                            </ul>
                         </li>
-                    </ol>
+                    </ul>
                 </li>
 
                 <li>
-                    <a id="B2"></a>Behavior Warranting Sanctions
-                    <ol>
+                    <a id="B2">B2.</a> Behavior Warranting Sanctions
+                    <ul>
                         <li>
-                            <a id="B2.A"></a>Poor Spirit
-                            <ol>
+                            <a id="B2.A">B2.A.</a> Poor Spirit
+                            <ul>
                                 <li>
-                                    A TMF will be issued when a team demonstrates a pattern of poor spirit or disregard for the rules, by committing intentional, repeated, or flagrant infractions.
-                                    <ol>
+                                    <a id="B2.A.1">B2.A.1.</a> A TMF will be issued when a team demonstrates a pattern of poor spirit or disregard for the rules, by committing intentional, repeated, or flagrant infractions.
+                                    <ul>
                                         <li>
-                                            If such a pattern is demonstrated by a single
+                                            <a id="B2.A.1.a">B2.A.1.a.</a> If such a pattern is demonstrated by a single
                                             <span class="tooltip" title="Any person designated by the team, to the event organizer, to be officially associated with the team, per the rules established by the event organizer.">team member</span>, a PMF will be issued to that <span class="tooltip" title="Any person designated by the team, to the event organizer, to be officially associated with the team, per the rules established by the event organizer.">team member</span>.
                                         </li>
-                                    </ol>
+                                    </ul>
                                 </li>
 
-                                <li>Behavior warranting such sanctions includes deliberate fouling, dangerous play, taunting, fighting, swearing directed at an official or opponent, repeated marking fouls, deliberate marking violations, making unwarranted calls or contests, or other blatant disregard of the rules.</li>
-                                <li>Any flagrant foul does not require a pattern to result in a TMF or PMF.</li>
-                                <li>A single particularly violent “harmful endangerment” infraction can be grounds for a PMF or an ejection, at the discretion of the observer who witnesses the incident.</li>
-                                <li>A single particularly egregious demonstration of disregard for the rules, such as an intentional infraction or clearly unfounded call, can be grounds for a TMF.</li>
-                            </ol>
+                                <li><a id="B2.A.2">B2.A.2.</a> Behavior warranting such sanctions includes deliberate fouling, dangerous play, taunting, fighting, swearing directed at an official or opponent, repeated marking fouls, deliberate marking violations, making unwarranted calls or contests, or other blatant disregard of the rules.</li>
+                                <li><a id="B2.A.3">B2.A.3.</a> Any flagrant foul does not require a pattern to result in a TMF or PMF.</li>
+                                <li><a id="B2.A.4">B2.A.4.</a> A single particularly violent “harmful endangerment” infraction can be grounds for a PMF or an ejection, at the discretion of the observer who witnesses the incident.</li>
+                                <li><a id="B2.A.5">B2.A.5.</a> A single particularly egregious demonstration of disregard for the rules, such as an intentional infraction or clearly unfounded call, can be grounds for a TMF.</li>
+                            </ul>
                         </li>
 
                         <li>
-                            <a id="B2.B"></a>Battery
-                            <ol>
+                            <a id="B2.B">B2.B.</a> Battery
+                            <ul>
                                 <li>
-                                    <a id="B2.B.1"></a>Intentionally striking another person with a part of the body, a disc or anything else, or any clear attempt to do so, warrants an ejection. This includes, but is not limited to: punching or kicking, or attempting to punch or kick, someone; spiking, or attempting to spike, a disc on someone; and spitting on someone, or spitting at someone but missing.
-                                    <ol>
+                                    <a id="B2.B.1">B2.B.1.</a> Intentionally striking another person with a part of the body, a disc or anything else, or any clear attempt to do so, warrants an ejection. This includes, but is not limited to: punching or kicking, or attempting to punch or kick, someone; spiking, or attempting to spike, a disc on someone; and spitting on someone, or spitting at someone but missing.
+                                    <ul>
                                         <li>
-                                            <a id="B2.B.1.a"></a>If a
+                                            <a id="B2.B.1.a">B2.B.1.a.</a> If a
                                             <span class="tooltip" title="Any person designated by the team, to the event organizer, to be officially associated with the team, per the rules established by the event organizer.">team member</span>
                                             spikes the disc without intending to hit another person, and it does hit an opposing
                                             <span class="tooltip" title="Any person designated by the team, to the event organizer, to be officially associated with the team, per the rules established by the event organizer.">team member</span>, a TMF or PMF may be assessed at the discretion of the observer.
                                         </li>
-                                    </ol>
+                                    </ul>
                                 </li>
-                            </ol>
+                            </ul>
                         </li>
 
                         <li>
-                            <a id="B2.C"></a>Swearing
-                            <ol>
-                                <li><a id="B2.C.1"></a>A TMF or PMF may be assessed for swearing if directed at an opposing <span class="tooltip" title="Any person designated by the team, to the event organizer, to be officially associated with the team, per the rules established by the event organizer.">team member</span>, any spectator, or observer.</li>
-                                <li><a id="B2.C.2"></a>Technical fouls will be issued for general, undirected swearing in accordance with any specific written guidelines for a given tournament.</li>
-                            </ol>
+                            <a id="B2.C">B2.C.</a> Swearing
+                            <ul>
+                                <li><a id="B2.C.1">B2.C.1.</a> A TMF or PMF may be assessed for swearing if directed at an opposing <span class="tooltip" title="Any person designated by the team, to the event organizer, to be officially associated with the team, per the rules established by the event organizer.">team member</span>, any spectator, or observer.</li>
+                                <li><a id="B2.C.2">B2.C.2.</a> Technical fouls will be issued for general, undirected swearing in accordance with any specific written guidelines for a given tournament.</li>
+                            </ul>
                         </li>
 
                         <li>
-                            <a id="B2.D"></a>Deliberate Fouling
-                            <ol>
-                                <li><a id="B2.D.1"></a>A TMF or PMF may be assessed for a particularly hard, dangerous, or deliberate foul.</li>
-                            </ol>
+                            <a id="B2.D">B2.D.</a> Deliberate Fouling
+                            <ul>
+                                <li><a id="B2.D.1">B2.D.1.</a> A TMF or PMF may be assessed for a particularly hard, dangerous, or deliberate foul.</li>
+                            </ul>
                         </li>
 
                         <li>
-                            <a id="B2.E"></a>Pushing/Shoving
-                            <ol>
-                                <li><a id="B2.E.1"></a>A TMF or PMF may be assessed for unwarranted aggressive (e.g. shoving) or dangerous (e.g. tripping) behavior.</li>
-                            </ol>
+                            <a id="B2.E">B2.E.</a> Pushing/Shoving
+                            <ul>
+                                <li><a id="B2.E.1">B2.E.1.</a> A TMF or PMF may be assessed for unwarranted aggressive (e.g. shoving) or dangerous (e.g. tripping) behavior.</li>
+                            </ul>
                         </li>
 
                         <li>
-                            <a id="B2.F"></a>Taunting
-                            <ol>
-                                <li><a id="B2.F.1"></a>Repeated or prolonged taunting, or any verbal abuse of <span class="tooltip" title="Any person designated by the team, to the event organizer, to be officially associated with the team, per the rules established by the event organizer.">team members</span>, fans, or USAU officials, warrants a TMF or PMF, depending on the severity of the offense.</li>
-                            </ol>
+                            <a id="B2.F">B2.F.</a> Taunting
+                            <ul>
+                                <li><a id="B2.F.1">B2.F.1.</a> Repeated or prolonged taunting, or any verbal abuse of <span class="tooltip" title="Any person designated by the team, to the event organizer, to be officially associated with the team, per the rules established by the event organizer.">team members</span>, fans, or USAU officials, warrants a TMF or PMF, depending on the severity of the offense.</li>
+                            </ul>
                         </li>
 
                         <li>
-                            <a id="B2.G"></a>Sideline Encroachment
-                            <ol>
+                            <a id="B2.G">B2.G.</a> Sideline Encroachment
+                            <ul>
                                 <li>
-                                    If, after being warned,
+                                    <a id="B2.G.12">B2.G.1.</a> If, after being warned,
                                     <span class="tooltip" title="Any person designated by the team, to the event organizer, to be officially associated with the team, per the rules established by the event organizer.">team members</span>
                                     continue to crowd the sideline, a Technical Foul may be issued.
                                 </li>
                                 <li>
-                                    If the
+                                    <a id="B2.G.2">B2.G.2.</a> If the
                                     <span class="tooltip" title="Any person designated by the team, to the event organizer, to be officially associated with the team, per the rules established by the event organizer.">team member's</span>
                                     encroachment interferes with play or an observer's ability to make a call, a TMF should be issued.
                                 </li>
-                            </ol>
+                            </ul>
                         </li>
 
-                        <li><a id="B2.H"></a>Any other behavior described by Article X of the USAU Bylaws may warrant a TMF at the discretion of the observer.</li>
-                        <li><a id="B2.I"></a>Any behavior that would warrant the issuance of a TMF, but which occurs in a game without <span class="tooltip" title="Observers are non-player game officials whose job is to support the players in implementing a safe, fair, and efficient game. Observers carefully watch the action of the game, assist with communication, help uphold self-officiating and the Spirit of the Game, assist with resolving calls as needed, and perform other duties as described in Section 19">observers</span>, can result in sanctions upon a complaint filed to the EDA.</li>
-                    </ol>
+                        <li><a id="B2.H">B2.H.</a> Any other behavior described by Article X of the USAU Bylaws may warrant a TMF at the discretion of the observer.</li>
+                        <li><a id="B2.I">B2.I.</a> Any behavior that would warrant the issuance of a TMF, but which occurs in a game without <span class="tooltip" title="Observers are non-player game officials whose job is to support the players in implementing a safe, fair, and efficient game. Observers carefully watch the action of the game, assist with communication, help uphold self-officiating and the Spirit of the Game, assist with resolving calls as needed, and perform other duties as described in Section 19">observers</span>, can result in sanctions upon a complaint filed to the EDA.</li>
+                    </ul>
                 </li>
 
                 <li>
-                    <a id="B3"></a>Implementation
-                    <ol>
+                    <a id="B3">B3.</a> Implementation
+                    <ul>
                         <li>
-                            <a id="B3.A"></a>Any observer may assess a Technical Foul, TMF, PMF, or ejection.
-                            <ol>
-                                <li><a id="B3.A.1"></a>The infraction must have been witnessed by at least one official.</li>
-                            </ol>
+                            <a id="B3.A">B3.A.</a> Any observer may assess a Technical Foul, TMF, PMF, or ejection.
+                            <ul>
+                                <li><a id="B3.A.1">B3.A.1.</a> The infraction must have been witnessed by at least one official.</li>
+                            </ul>
                         </li>
 
                         <li>
-                            <a id="B3.B"></a>For PMFs and ejections, play stops as soon as possible.
-                            <ol>
-                                <li><a id="B3.B.1"></a>For the purpose of the Continuation Rule (<a href="https://usaultimate.org/rules/#17.C">17.C</a>), the situation should be treated like an injury called at the time of the infraction.</li>
-                            </ol>
+                            <a id="B3.B">B3.B.</a> For PMFs and ejections, play stops as soon as possible.
+                            <ul>
+                                <li><a id="B3.B.1">B3.B.1.</a> For the purpose of the Continuation Rule (<a href="https://usaultimate.org/rules/#17.C">17.C</a>), the situation should be treated like an injury called at the time of the infraction.</li>
+                            </ul>
                         </li>
 
-                        <li><a id="B3.C"></a>For Technical Fouls and TMFs, active play should not be stopped; the foul should be assessed at the next <span class="tooltip" title="Any halting of play due to a call, discussion, or timeout that requires a check or self-check to restart play. The term play stops means a stoppage of play occurs.">stoppage of play</span>.</li>
+                        <li><a id="B3.C">B3.C.</a> For Technical Fouls and TMFs, active play should not be stopped; the foul should be assessed at the next <span class="tooltip" title="Any halting of play due to a call, discussion, or timeout that requires a check or self-check to restart play. The term play stops means a stoppage of play occurs.">stoppage of play</span>.</li>
                         <li>
-                            <a id="B3.D"></a>Personal Misconduct Fouls and Ejections
-                            <ol>
+                            <a id="B3.D">B3.D.</a> Personal Misconduct Fouls and Ejections
+                            <ul>
                                 <li>
-                                    <a id="B3.D.1"></a>An ejected
+                                    <a id="B3.D.1">B3.D.1.</a> An ejected
                                     <span class="tooltip" title="Any person designated by the team, to the event organizer, to be officially associated with the team, per the rules established by the event organizer.">team member</span>
                                     must immediately leave the general area where their game is being played, as directed by the EDA.
-                                    <ol>
+                                    <ul>
                                         <li>
-                                            <a id="B3.D.1.a"></a>In practice this means the
+                                            <a id="B3.D.1.a">B3.D.1.a.</a> In practice this means the
                                             <span class="tooltip" title="Any person designated by the team, to the event organizer, to be officially associated with the team, per the rules established by the event organizer.">team member</span>
                                             must remove themselves at least 100 yards from their team's current playing field and refrain from interacting with any
                                             <span class="tooltip" title="Any person designated by the team, to the event organizer, to be officially associated with the team, per the rules established by the event organizer.">team members</span>, spectators, or officials involved in that game.
                                         </li>
                                         <li>
-                                            <a id="B3.D.1.b"></a>Failure to do so results in a forfeit for that
+                                            <a id="B3.D.1.b">B3.D.1.b.</a> Failure to do so results in a forfeit for that
                                             <span class="tooltip" title="Any person designated by the team, to the event organizer, to be officially associated with the team, per the rules established by the event organizer.">team member's</span>
                                             team.
                                         </li>
-                                    </ol>
+                                    </ul>
                                 </li>
 
                                 <li>
-                                    <a id="B3.D.2"></a>If a
+                                    <a id="B3.D.2">B3.D.2.</a> If a
                                     <span class="tooltip" title="Any person designated by the team, to the event organizer, to be officially associated with the team, per the rules established by the event organizer.">team member</span>
                                     participates in a game from which they have been ejected, that
                                     <span class="tooltip" title="Any person designated by the team, to the event organizer, to be officially associated with the team, per the rules established by the event organizer.">team member</span>
@@ -2395,94 +2400,94 @@
                                     <span class="tooltip" title="Any person designated by the team, to the event organizer, to be officially associated with the team, per the rules established by the event organizer.">team member's</span>
                                     team forfeits that game, and harsher sanctions may also result, depending on the event.
                                 </li>
-                                <li><a id="B3.D.3"></a>A team whose player is ejected may substitute another player, and the opposing team also may exchange a player if they wish.</li>
-                                <li><a id="B3.D.4"></a>All players must remain in the positions they occupied when play stopped, unless the ejection also triggers a Team Misconduct Penalty, as described in the following sections.</li>
-                            </ol>
+                                <li><a id="B3.D.3">B3.D.3.</a> A team whose player is ejected may substitute another player, and the opposing team also may exchange a player if they wish.</li>
+                                <li><a id="B3.D.4">B3.D.4.</a> All players must remain in the positions they occupied when play stopped, unless the ejection also triggers a Team Misconduct Penalty, as described in the following sections.</li>
+                            </ul>
                         </li>
 
                         <li>
-                            <a id="B3.E"></a>Team Misconduct Penalty Against the Offense
-                            <ol>
+                            <a id="B3.E">B3.E.</a> Team Misconduct Penalty Against the Offense
+                            <ul>
                                 <li>
-                                    <a id="B3.E.1"></a>There are two options available to the defense to continue play after a Team Misconduct Penalty against the offense assessed during a <span class="tooltip" title="Any halting of play due to a call, discussion, or timeout that requires a check or self-check to restart play. The term play stops means a stoppage of play occurs.">stoppage of play</span>.
-                                    <ol>
+                                    <a id="B3.E.1">B3.E.1.</a> There are two options available to the defense to continue play after a Team Misconduct Penalty against the offense assessed during a <span class="tooltip" title="Any halting of play due to a call, discussion, or timeout that requires a check or self-check to restart play. The term play stops means a stoppage of play occurs.">stoppage of play</span>.
+                                    <ul>
                                         <li>
-                                            <a id="B3.E.1.a"></a>The disc is moved to the reverse brick mark, away from the end zone of attack. The offense is given 30 seconds to set up anywhere on the playing field. After all
+                                            <a id="B3.E.1.a">B3.E.1.a.</a> The disc is moved to the reverse brick mark, away from the end zone of attack. The offense is given 30 seconds to set up anywhere on the playing field. After all
                                             <span class="tooltip" title="A player whose team is in possession of the disc.">offensive players</span>
                                             have assumed stationary positions, the defense has an additional 20 seconds to match up and check the disc in with a stall count of one.
                                         </li>
-                                        <li><a id="B3.E.1.b"></a>The disc and players stay where they were when play stopped. Once players are ready, the count resumes at the stall count reached plus one, or at nine if over eight.</li>
-                                    </ol>
+                                        <li><a id="B3.E.1.b">B3.E.1.b.</a> The disc and players stay where they were when play stopped. Once players are ready, the count resumes at the stall count reached plus one, or at nine if over eight.</li>
+                                    </ul>
                                 </li>
-                            </ol>
+                            </ul>
                         </li>
 
                         <li>
-                            <a id="B3.F"></a>Team Misconduct Penalty Against the Defense
-                            <ol>
+                            <a id="B3.F">B3.F.</a> Team Misconduct Penalty Against the Defense
+                            <ul>
                                 <li>
-                                    <a id="B3.F.1"></a>There are three options available to the offense to continue play after a Team Misconduct Penalty against the defense assessed during a <span class="tooltip" title="Any halting of play due to a call, discussion, or timeout that requires a check or self-check to restart play. The term play stops means a stoppage of play occurs.">stoppage of play</span>.
-                                    <ol>
+                                    <a id="B3.F.1">B3.F.1.</a> There are three options available to the offense to continue play after a Team Misconduct Penalty against the defense assessed during a <span class="tooltip" title="Any halting of play due to a call, discussion, or timeout that requires a check or self-check to restart play. The term play stops means a stoppage of play occurs.">stoppage of play</span>.
+                                    <ul>
                                         <li>
-                                            <a id="B3.F.1.a"></a>The disc is moved to the brick mark closest to the end zone of attack. The offense has 30 seconds to set up anywhere on the playing field. After all
+                                            <a id="B3.F.1.a">B3.F.1.a.</a> The disc is moved to the brick mark closest to the end zone of attack. The offense has 30 seconds to set up anywhere on the playing field. After all
                                             <span class="tooltip" title="A player whose team is in possession of the disc.">offensive players</span>
                                             have assumed stationary positions, the defense has an additional 20 seconds to match up and check the disc in with a stall count of one.
                                         </li>
                                         <li>
-                                            <a id="B3.F.1.b"></a>The disc is centered on the long axis of the field. The offense has 30 seconds to set up anywhere on the playing field. After all
+                                            <a id="B3.F.1.b">B3.F.1.b.</a> The disc is centered on the long axis of the field. The offense has 30 seconds to set up anywhere on the playing field. After all
                                             <span class="tooltip" title="A player whose team is in possession of the disc.">offensive players</span>
                                             have assumed stationary positions, the defense has an additional 20 seconds to match up and check the disc in with a stall count of one.
                                         </li>
-                                        <li><a id="B3.F.1.c"></a>The disc and players stay where they were when play stopped. Once players are ready, the defense checks in the disc with a stall count of one.</li>
-                                    </ol>
+                                        <li><a id="B3.F.1.c">B3.F.1.c.</a> The disc and players stay where they were when play stopped. Once players are ready, the defense checks in the disc with a stall count of one.</li>
+                                    </ul>
                                 </li>
-                            </ol>
+                            </ul>
                         </li>
 
                         <li>
-                            <a id="B3.G"></a>Team Misconduct Penalty Assessed Between Points
-                            <ol>
-                                <li><a id="B3.G.1"></a>If a Team Misconduct Penalty is assessed after the completion of a point, there is no pull.</li>
-                                <li><a id="B3.G.2"></a>If the penalty is against the receiving team, the disc is put into play at the brick mark in the end zone they are defending (refer to TMF against offense above).</li>
-                                <li><a id="B3.G.3"></a>If the penalty is against the pulling team, the receiving team puts the disc into play at the brick mark closest to the end zone they are attacking (refer to TMF against defense above, <a href="https://usaultimate.org/rules/#B3.F">B3.F</a>).</li>
-                                <li><a id="B3.G.4"></a>Each team may substitute players as per <a href="https://usaultimate.org/rules/#8.A.1">8.A.1</a>.</li>
+                            <a id="B3.G">B3.G.</a> Team Misconduct Penalty Assessed Between Points
+                            <ul>
+                                <li><a id="B3.G.1">B3.G.1.</a> If a Team Misconduct Penalty is assessed after the completion of a point, there is no pull.</li>
+                                <li><a id="B3.G.2">B3.G.2.</a> If the penalty is against the receiving team, the disc is put into play at the brick mark in the end zone they are defending (refer to TMF against offense above).</li>
+                                <li><a id="B3.G.3">B3.G.3.</a> If the penalty is against the pulling team, the receiving team puts the disc into play at the brick mark closest to the end zone they are attacking (refer to TMF against defense above, <a href="https://usaultimate.org/rules/#B3.F">B3.F</a>).</li>
+                                <li><a id="B3.G.4">B3.G.4.</a> Each team may substitute players as per <a href="https://usaultimate.org/rules/#8.A.1">8.A.1</a>.</li>
                                 <li>
-                                    <a id="B3.G.5"></a>Each
+                                    <a id="B3.G.5">B3.G.5.</a> Each
                                     <span class="tooltip" title="A player whose team is in possession of the disc.">offensive player</span>
                                     must establish a stationary position by 90 seconds after the previous goal was scored.
                                 </li>
                                 <li>
-                                    <a id="B3.G.6"></a>The defense has 105 seconds after the previous goal was scored or up to 15 seconds after all
+                                    <a id="B3.G.6">B3.G.6.</a> The defense has 105 seconds after the previous goal was scored or up to 15 seconds after all
                                     <span class="tooltip" title="A player whose team is in possession of the disc.">offensive players</span>
                                     have established their positions (whichever is longer) to check the disc into play.
                                 </li>
-                            </ol>
+                            </ul>
                         </li>
 
                         <li>
-                            <a id="B3.H"></a>Declined Team Misconduct Penalties
-                            <ol>
+                            <a id="B3.H">B3.H.</a> Declined Team Misconduct Penalties
+                            <ul>
                                 <li>
-                                    <a id="B3.H.1"></a>A
+                                    <a id="B3.H.1">B3.H.1.</a> A
                                     <span class="tooltip" title="A team member, who is eligible to participate in the game, and has been designated to represent the team in decision-making on behalf of the team before, during, and after a game.">captain</span>
                                     can decline a misconduct penalty and leave the disc as is.
                                 </li>
                                 <li>
-                                    <a id="B3.H.2"></a>In exceptional circumstances,
+                                    <a id="B3.H.2">B3.H.2.</a> In exceptional circumstances,
                                     <span class="tooltip" title="Observers are non-player game officials whose job is to support the players in implementing a safe, fair, and efficient game. Observers carefully watch the action of the game, assist with communication, help uphold self-officiating and the Spirit of the Game, assist with resolving calls as needed, and perform other duties as described in Section 19">observers</span>
                                     may deny the declination if they feel the teams are trying to circumvent mandatory tournament rules, guidelines, or player safety.
                                 </li>
-                            </ol>
+                            </ul>
                         </li>
-                    </ol>
+                    </ul>
                 </li>
-            </ol>
+            </ul>
         </li>
         <li>
-            <a id="appendix_c"></a>Appendix C: Hand Signals
-            <ol>
+            <a id="appendix_c">Appendix C:</a> Hand Signals
+            <ul>
                 <li>
-                    <a id="C1"></a>Player and Observer Hand Signals
+                    <a id="C1">C1.</a> Player and Observer Hand Signals
 
                     <table class="handSignals">
                         <tbody>
@@ -2665,7 +2670,7 @@
                 </li>
 
                 <li>
-                    <a id="C2"></a>Observer Only Hand Signals
+                    <a id="C2">C2.</a> Observer Only Hand Signals
 
                     <table class="handSignals">
                         <tbody>
@@ -2700,27 +2705,27 @@
                         </tbody>
                     </table>
                 </li>
-            </ol>
+            </ul>
         </li>
         <li>
-            <a id="appendix_d"></a>Appendix D: Youth Rules Adaptations
+            <a id="appendix_d">Appendix D:</a> Youth Rules Adaptations
             <div class="rulesBody plain">The following adaptations to the rules are recommended for youth ultimate competitions, as defined below. These adaptations may be additions to the current official rules or may supersede existing rules. Other than these additions and changes, the current official rules will apply to youth competition.</div>
             <div class="rulesBody plain">The goals for Youth Rules Adaptations are to modify the game to make it both safer and more developmentally appropriate for various age groups. The current age categories are a general approximation of development levels, and are also in part based on factors such as school levels and the breakdown of current age groups participating in the sport. These are likely to become more refined in the future.</div>
-            <ol>
+            <ul>
                 <li>
-                    <a id="D1"></a>Requirements
-                    <ol>
-                        <li><a id="D1.A"></a>There are not currently any requirements for rules adaptations for youth under this edition of the rules. Requirements are likely to come in future editions based on continued research and experience with adapting the sport for youth age groups.</li>
-                    </ol>
+                    <a id="D1">D1.</a> Requirements
+                    <ul>
+                        <li><a id="D1.A">D1.A.</a> There are not currently any requirements for rules adaptations for youth under this edition of the rules. Requirements are likely to come in future editions based on continued research and experience with adapting the sport for youth age groups.</li>
+                    </ul>
                 </li>
 
                 <li>
-                    <a id="D2"></a>Recommendations
-                    <ol>
-                        <li><a id="D2.A"></a>These rule adaptations are not required, but are optional recommendations taken in whole or in part, to help younger players learn to play in a more developmentally appropriate environment.</li>
-                    </ol>
+                    <a id="D2">D2.</a> Recommendations
+                    <ul>
+                        <li><a id="D2.A">D2.A.</a> These rule adaptations are not required, but are optional recommendations taken in whole or in part, to help younger players learn to play in a more developmentally appropriate environment.</li>
+                    </ul>
                 </li>
-            </ol>
+            </ul>
 
             <table class="normal youth">
                 <colgroup>
@@ -2874,96 +2879,96 @@
             </table>
         </li>
         <li>
-            <a id="appendix_e"></a>Appendix E: Beach Ultimate Rules Adaptations
+            <a id="appendix_e">Appendix E:</a> Beach Ultimate Rules Adaptations
             <div class="rulesBody plain">The following adaptations to the rules are to be used in beach or sand ultimate competitions. These adaptations may be additions to the current official rules or may supersede existing rules. Other than these additions and changes, the current official rules will apply to beach or sand competition.</div>
-            <ol>
+            <ul>
                 <li>
-                    <a id="E1"></a>Number of Players
-                    <ol>
+                    <a id="E1">E1.</a> Number of Players
+                    <ul>
                         <li>The recommended number of players per team is either five (5) or four (4).</li>
-                    </ol>
+                    </ul>
                 </li>
 
                 <li>
-                    <a id="E2"></a>Playing Field
-                    <ol>
+                    <a id="E2">E2.</a> Playing Field
+                    <ul>
                         <li>
-                            <a id="E2.A"></a>5v5 Field Dimensions
-                            <ol>
+                            <a id="E2.A">E2.A.</a> 5v5 Field Dimensions
+                            <ul>
                                 <li>The standard field of play, including end zones, is 82 yards (75 meters) long and 27 yards (25 meters) wide.</li>
                                 <li>The standard end zone is 16 yards (15 meters) deep.</li>
                                 <li>The brick marks are located 11 yards (10 meters) from the goal line.</li>
-                            </ol>
+                            </ul>
                         </li>
 
                         <li>
-                            <a id="E2.B"></a>4v4 Field Dimensions
-                            <ol>
+                            <a id="E2.B">E2.B.</a> 4v4 Field Dimensions
+                            <ul>
                                 <li>The standard field of play, including end zones, is 50 yards (45 meters) long and 30 yards (27 meters) wide.</li>
                                 <li>The standard end zone is 8 yards (7.5 meters) deep.</li>
                                 <li>The brick marks are located 8 yards (7.5 meters) from the goal line.</li>
-                            </ol>
+                            </ul>
                         </li>
 
                         <li>
-                            <a id="E2.C"></a>Perimeter and end zone lines are established with field lining tape (preferred) or rope.
-                            <ol>
+                            <a id="E2.C">E2.C.</a> Perimeter and end zone lines are established with field lining tape (preferred) or rope.
+                            <ul>
                                 <li>The top of the tape is the portion of the field tape that is facing upwards. Should the tape twist along its length, the “top” is always the side that is facing up, even if that changes along the length.</li>
-                            </ol>
+                            </ul>
                         </li>
 
-                        <li><a id="E2.D"></a>The top of the perimeter lines is not part of the playing field and is out-of-bounds.</li>
-                        <li><a id="E2.E"></a>The area directly under the perimeter lines and all parts of the perimeter lines excluding the top of the tape are part of the playing field and in-bounds.</li>
-                        <li><a id="E2.F"></a>The top of the goal line is part of the central zone.</li>
-                        <li><a id="E2.G"></a>The area directly under the goal line and all parts of the goal line excluding the top of the tape are part of the end zone.</li>
-                    </ol>
+                        <li><a id="E2.D">E2.D.</a> The top of the perimeter lines is not part of the playing field and is out-of-bounds.</li>
+                        <li><a id="E2.E">E2.E.</a> The area directly under the perimeter lines and all parts of the perimeter lines excluding the top of the tape are part of the playing field and in-bounds.</li>
+                        <li><a id="E2.F">E2.F.</a> The top of the goal line is part of the central zone.</li>
+                        <li><a id="E2.G">E2.G.</a> The area directly under the goal line and all parts of the goal line excluding the top of the tape are part of the end zone.</li>
+                    </ul>
                 </li>
 
                 <li>
-                    <a id="E3"></a>Equipment
-                    <ol>
-                        <li><a id="E3.A"></a>Shoes and cleats are not allowed. Players' feet must be bare or only have a soft covering such as socks or tape.</li>
-                    </ol>
+                    <a id="E3">E3.</a> Equipment
+                    <ul>
+                        <li><a id="E3.A">E3.A.</a> Shoes and cleats are not allowed. Players' feet must be bare or only have a soft covering such as socks or tape.</li>
+                    </ul>
                 </li>
 
                 <li>
-                    <a id="E4"></a>Length of Game
-                    <ol>
+                    <a id="E4">E4.</a> Length of Game
+                    <ul>
                         <li>
-                            <a id="E4.A"></a>A standard game has
-                            <ol>
-                                <li><a id="E4.A.1"></a>a game total of 13,</li>
-                                <li><a id="E4.A.2"></a>a soft caap at 50 minutes,</li>
-                                <li><a id="E4.A.3"></a>a hard cap at 60 minutes,</li>
-                                <li><a id="E4.A.4"></a>a halftime of 5 minutes, and</li>
-                                <li><a id="E4.A.5"></a>1 team timeout per game.</li>
-                            </ol>
+                            <a id="E4.A">E4.A.</a> A standard game has
+                            <ul>
+                                <li><a id="E4.A.1">E4.A.1.</a> a game total of 13,</li>
+                                <li><a id="E4.A.2">E4.A.2.</a> a soft caap at 50 minutes,</li>
+                                <li><a id="E4.A.3">E4.A.3.</a> a hard cap at 60 minutes,</li>
+                                <li><a id="E4.A.4">E4.A.4.</a> a halftime of 5 minutes, and</li>
+                                <li><a id="E4.A.5">E4.A.5.</a> 1 team timeout per game.</li>
+                            </ul>
                         </li>
-                    </ol>
+                    </ul>
                 </li>
 
                 <li>
-                    <a id="E5"></a>Sand Stoppages
-                    <ol>
+                    <a id="E5">E5.</a> Sand Stoppages
+                    <ul>
                         <li>
-                            <a id="E5.A"></a>Any player may briefly extend a
+                            <a id="E5.A">E5.A.</a> Any player may briefly extend a
                             <span class="tooltip" title="Any halting of play due to a call, discussion, or timeout that requires a check or self-check to restart play. The term play stops means a stoppage of play occurs.">stoppage of play</span>
                             to remove interfering sand from their face, but active play may not be stopped for this purpose.
                         </li>
-                    </ol>
+                    </ul>
                 </li>
 
                 <li>
-                    <a id="E6"></a>Sand Fouls
-                    <ol>
-                        <li><a id="E6.A"></a>A sand foul occurs when a player causes sand to fly into an opponent's face in a way that significantly interferes with their play, such as in the eyes or up their nose.</li>
-                        <li><a id="E6.B"></a>A sand foul is considered distinct and separate to the action that caused it and should be resolved separately as such.</li>
-                    </ol>
+                    <a id="E6">E6.</a> Sand Fouls
+                    <ul>
+                        <li><a id="E6.A">E6.A.</a> A sand foul occurs when a player causes sand to fly into an opponent's face in a way that significantly interferes with their play, such as in the eyes or up their nose.</li>
+                        <li><a id="E6.B">E6.B.</a> A sand foul is considered distinct and separate to the action that caused it and should be resolved separately as such.</li>
+                    </ul>
                 </li>
-            </ol>
+            </ul>
         </li>
         <li>
-            <a id="appendix_f"></a>Appendix F: Ultimate 4's Rules Adaptations
+            <a id="appendix_f">Appendix F:</a> Ultimate 4's Rules Adaptations
             <div class="rulesBody plain"><strong>Overview</strong> – Ultimate 4's is an exciting and accessible variation of ultimate adapted for smaller teams and smaller fields. Like other variations that use smaller numbers, such as Beach Ultimate, 4's helps create an opportunity for more involvement from everyone on the field. With shorter stall counts, play moves at a faster pace, and the smaller field creates a space where more throwers can reach all areas of the field. The need for fewer people and less field space makes the sport more accessible in multiple ways. While played with most of the same rules as regulation ultimate, including field surface, matches consist of multiple short games rather than one long one. The first team to win two of the three games wins the match, a format which lends itself to exciting comebacks and thrilling tie-breakers.</div>
             <div class="ruleBody plain">The following adaptations to the rules are to be used in Ultimate 4's competition. These adaptations may be additions to the current official rules or may supersede existing rules. Other than these additions and changes, the current official rules apply to Ultimate 4's competition.</div>
 
@@ -3071,5 +3076,6 @@
             <div class="ruleBody plain">** Rather than re-determining choice at the start of the tie-break, the pull and sides could be determined by continuing the ongoing alternating sequence, automatically giving the team that wins the first game first possession in the tie-break. Or give the previous losing team first choice of side/possession in second (and third) games.</div>
             <div class="ruleBody plain">*** The sweep point differential bonus could be adjusted up or down. Tie-breaks could also be considered that track games won/lost differential and gives a +1 game bonus to a sweep before moving on to point differential.</div>
         </li>
-    </ol>
+    </ul>
 </div>
+</body></html>

--- a/html/2024-2025.html
+++ b/html/2024-2025.html
@@ -301,7 +301,7 @@
                     <span class="annotation">[[Play-halting calls include “foul,” “violation,” “pick,” “stall,” etc.]]</span>
                 </li>
                 <li>
-                    <a id="3.O">3.O.</a> A disc in flight following any throwing motion (including a fake) that results in the thrower losing contact with the disc.
+                    <a id="3.O">3.O.</a>Throw: A disc in flight following any throwing motion (including a fake) that results in the thrower losing contact with the disc.
                     <span class="annotation">[[Generally, a non-spinning, falling disc is not “in flight” unless it is intentionally dropped.]]</span>
                     <ul>
                         <li><a id="3.O.1">3.O.1.</a> A pass is equivalent to a throw.</li>


### PR DESCRIPTION
Using manual numbers facilitates copy+paste use case. Previously, when you copy+paste rules, the numbers don't copy.

Updated the css to match.

*******Before merging this PR, the site css must match this new rules css.